### PR TITLE
menu: don't load garbage in time_dec_day

### DIFF
--- a/snes/time.a65
+++ b/snes/time.a65
@@ -438,7 +438,9 @@ time_dec_cont
 	lda time_mon
 	dec
 	asl
-	ldx #$0000
+	xba
+	lda #$00
+	xba
 	tax
 	lda @time_month, x
 	sta time_d10


### PR DESCRIPTION
(TAX with 16-bit X/Y causes the full 16 bits of A to get transferred,
and this was causing invalid day numbers to be displayed on screen
most/all of the time when decrementing the day past 01)
