### PR TITLE
menu: reset X-scroll state when pressing R

### DIFF
--- a/snes/filesel.a65
+++ b/snes/filesel.a65
@@ -504,6 +504,8 @@ filesel_key_l:
   rts
 
 filesel_key_r:
+  stz direntry_xscroll
+  stz direntry_xscroll_state
   lda dirend_onscreen
   beq +
   jmp fileselupd_lastcursor


### PR DESCRIPTION
This fixes a bug where pressing R to scroll down by at least one full page with a long file name highlighted would cause the visible file names to become corrupted.