### PR TITLE
Add binaries to gitignore for tools, u_int fixes, some Makefile changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ autoconf.h
 utils/rle
 utils/derle
 *.bit
+*.bi3
 *.i
 *.s
 *.txt
@@ -120,3 +121,12 @@ cic/supercic/supercic-key.hex
 cic/supercic/supercic-lock.hex
 contrib/*
 docs/*
+
+utils/bin2asm
+utils/bin2c
+utils/chili2chr
+utils/genbsxpage
+utils/gentilemap
+utils/mem2lorom
+utils/palremap
+utils/palreorder

--- a/utils/mem2lorom.c
+++ b/utils/mem2lorom.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 int main(int argc, char **argv) {
   if(argc<1){

--- a/verilog/common.mk
+++ b/verilog/common.mk
@@ -1,0 +1,9 @@
+HOST = LINUX
+XILINX_HOME = /opt/Xilinx/14.7/ISE_DS
+XILINX_BIN = $(XILINX_HOME)/ISE/bin/lin64
+XILINX_PATHS = ISE/bin/lin64 ISE/lib/lin64 PlanAhead/bin EDK/bin/lib64 EDK/lib/lin64
+
+INTEL_BIN = /opt/intelFPGA_lite/18.1/quartus/linux64
+
+XPLORER_PARAMS=-sf currentProps.stratfile -host_list hostlistfile.txt -max_runs 99 -best_n_runs 1
+#XPLORER_PARAMS=-max_runs 5 -best_n_runs 1

--- a/verilog/sd2snes_base/Makefile
+++ b/verilog/sd2snes_base/Makefile
@@ -1,19 +1,16 @@
+include ../common.mk
 # This is a rather primitive Makefile to facilitate (re)compilation of the FPGA
 # core. It assumes that an initial project setup/compilation, particularly of
 # any IP cores used, has taken place using the vendor's corresponding FPGA
 # development environment.
 
 # build on Windows
-HOST = CYGWIN
 CORE = base
 XILINX_PART = xc3s400-pq208-4
 
 # set paths to Xilinx/Intel tools, adjust these for your environment
 mkpath = $(subst $(eval) ,:,$(wildcard $1))
-XILINX_HOME = /cygdrive/d/Xilinx/14.7/ISE_DS
 XILINX := $(XILINX_HOME)/ISE
-XILINX_BIN = $(XILINX_HOME)/ISE/bin/nt64
-XILINX_PATHS = ISE/bin/nt64 ISE/lib/nt64 PlanAhead/bin EDK/bin/nt64 EDK/lib/nt64
 XILINX_EDK := $(XILINX_HOME)/EDK
 XILINX_PLANAHEAD := $(XILINX_HOME)/PlanAhead
 XILINX_DSP := $(XILINX_HOME)/ISE
@@ -32,8 +29,6 @@ endif
 XILINX_CT = $(shell grep Cost.*Map sd2snes_$(CORE).xise | sed -e 's/.*value="\([0-9]\+\)".*$$/\1/g')
 XILINX_MAP_OPTS = -timing -logic_opt on -ol high -xe n -register_duplication on -cm area -ir off -pr b -power off
 XILINX_PAR_OPTS = -ol high -xe n
-
-INTEL_BIN = /cygdrive/d/intelFPGA_lite/18.1/quartus/bin64
 
 VSRC = address.v cheat.v clk_test.v dac.v dcm.v bsx.v srtc.v upd77c25.v main.v mcu_cmd.v msu.v sd_dma.v spi.v
 VHSRC =

--- a/verilog/sd2snes_cx4/Makefile
+++ b/verilog/sd2snes_cx4/Makefile
@@ -1,19 +1,16 @@
+include ../common.mk
+
 # This is a rather primitive Makefile to facilitate (re)compilation of the FPGA
 # core. It assumes that an initial project setup/compilation, particularly of
 # any IP cores used, has taken place using the vendor's corresponding FPGA
 # development environment.
 
-# build on Windows
-HOST = CYGWIN
 CORE = cx4
 XILINX_PART = xc3s400-pq208-4
 
 # set paths to Xilinx/Intel tools, adjust these for your environment
 mkpath = $(subst $(eval) ,:,$(wildcard $1))
-XILINX_HOME = /cygdrive/d/Xilinx/14.7/ISE_DS
 XILINX := $(XILINX_HOME)/ISE
-XILINX_BIN = $(XILINX_HOME)/ISE/bin/nt64
-XILINX_PATHS = ISE/bin/nt64 ISE/lib/nt64 PlanAhead/bin EDK/bin/nt64 EDK/lib/nt64
 XILINX_EDK := $(XILINX_HOME)/EDK
 XILINX_PLANAHEAD := $(XILINX_HOME)/PlanAhead
 XILINX_DSP := $(XILINX_HOME)/ISE
@@ -32,8 +29,6 @@ endif
 XILINX_CT = $(shell grep Cost.*Map sd2snes_$(CORE).xise | sed -e 's/.*value="\([0-9]\+\)".*$$/\1/g')
 XILINX_MAP_OPTS = -timing -logic_opt on -ol high -xe n -register_duplication on -cm area -ir off -pr b -power off
 XILINX_PAR_OPTS = -ol high -xe n
-
-INTEL_BIN = /cygdrive/d/intelFPGA_lite/18.1/quartus/bin64
 
 VSRC = address.v cheat.v clk_test.v dac.v dcm.v cx4.v main.v mcu_cmd.v msu.v sd_dma.v spi.v
 VHSRC =
@@ -60,11 +55,11 @@ mk3: fpga_$(CORE).bi3
 # build mk2 using SmartXPlorer (useful for cx4, gsu, sa1, sdd1)
 mk2s: smartxplorer
 
-smartxplorer: main.ngc
+smartxplorer: main.ngd
 	rm -rf smartxplorer_results
 	PATH="$(XILINX_PATH)":"$(PATH)"; \
 	export XILINX="$(XILINX)" XILINX_DSP="$(XILINX_DSP)" XILINX_EDK="$(XILINX_EDK)" XILINX_PLANAHEAD="$(XILINX_PLANAHEAD)"; \
-	smartxplorer -sf currentProps.stratfile -p $(XILINX_PART) -b -wd smartxplorer_results main.ngd -to "-v 3 -s 4 -n 3 -fastpaths -xml main.twx -ucf main.ucf" -host_list hostlistfile.txt -max_runs 99 -best_n_runs 1 \
+	$(XILINX_BIN)/smartxplorer -p $(XILINX_PART) -b -wd smartxplorer_results main.ngd -to "-v 3 -s 4 -n 3 -fastpaths -xml main.twx -ucf main.ucf" $(XPLORER_PARAMS) \
 	&& (while true; do \
 		touch $@; \
 		export SX_RUN=`grep "Run index" smartxplorer_results/smartxplorer.log | sed -e 's/^.*\:.*run\([0-9]\+\).*$$/\1/g'`; \

--- a/verilog/sd2snes_gsu/Makefile
+++ b/verilog/sd2snes_gsu/Makefile
@@ -1,19 +1,16 @@
+include ../common.mk
 # This is a rather primitive Makefile to facilitate (re)compilation of the FPGA
 # core. It assumes that an initial project setup/compilation, particularly of
 # any IP cores used, has taken place using the vendor's corresponding FPGA
 # development environment.
 
 # build on Windows
-HOST = CYGWIN
 CORE = gsu
 XILINX_PART = xc3s400-pq208-4
 
 # set paths to Xilinx/Intel tools, adjust these for your environment
 mkpath = $(subst $(eval) ,:,$(wildcard $1))
-XILINX_HOME = /cygdrive/d/Xilinx/14.7/ISE_DS
 XILINX := $(XILINX_HOME)/ISE
-XILINX_BIN = $(XILINX_HOME)/ISE/bin/nt64
-XILINX_PATHS = ISE/bin/nt64 ISE/lib/nt64 PlanAhead/bin EDK/bin/nt64 EDK/lib/nt64
 XILINX_EDK := $(XILINX_HOME)/EDK
 XILINX_PLANAHEAD := $(XILINX_HOME)/PlanAhead
 XILINX_DSP := $(XILINX_HOME)/ISE
@@ -32,8 +29,6 @@ endif
 XILINX_CT = $(shell grep Cost.*Map sd2snes_$(CORE).xise | sed -e 's/.*value="\([0-9]\+\)".*$$/\1/g')
 XILINX_MAP_OPTS = -timing -logic_opt on -ol high -xe n -register_duplication on -cm area -ir off -pr b -power off
 XILINX_PAR_OPTS = -ol high -xe n
-
-INTEL_BIN = /cygdrive/d/intelFPGA_lite/18.1/quartus/bin64
 
 VSRC = address.v cheat.v dac.v dcm.v gsu.v main.v mcu_cmd.v msu.v sd_dma.v spi.v
 VHSRC =
@@ -60,11 +55,11 @@ mk3: fpga_$(CORE).bi3
 # build mk2 using SmartXPlorer (useful for cx4, gsu, sa1, sdd1)
 mk2s: smartxplorer
 
-smartxplorer: main.ngc
+smartxplorer: main.ngd
 	rm -rf smartxplorer_results
 	PATH="$(XILINX_PATH)":"$(PATH)"; \
 	export XILINX="$(XILINX)" XILINX_DSP="$(XILINX_DSP)" XILINX_EDK="$(XILINX_EDK)" XILINX_PLANAHEAD="$(XILINX_PLANAHEAD)"; \
-	smartxplorer -sf currentProps.stratfile -p $(XILINX_PART) -b -wd smartxplorer_results main.ngd -to "-v 3 -s 4 -n 3 -fastpaths -xml main.twx -ucf main.ucf" -host_list hostlistfile.txt -max_runs 99 -best_n_runs 1 \
+	smartxplorer -p $(XILINX_PART) -b -wd smartxplorer_results main.ngd -to "-v 3 -s 4 -n 3 -fastpaths -xml main.twx -ucf main.ucf" $(XPLORER_PARAMS) \
 	&& (while true; do \
 		touch $@; \
 		export SX_RUN=`grep "Run index" smartxplorer_results/smartxplorer.log | sed -e 's/^.*\:.*run\([0-9]\+\).*$$/\1/g'`; \

--- a/verilog/sd2snes_mini/Makefile
+++ b/verilog/sd2snes_mini/Makefile
@@ -1,19 +1,16 @@
+include ../common.mk
 # This is a rather primitive Makefile to facilitate (re)compilation of the FPGA
 # core. It assumes that an initial project setup/compilation, particularly of
 # any IP cores used, has taken place using the vendor's corresponding FPGA
 # development environment.
 
 # build on Windows
-HOST = CYGWIN
 CORE = mini
 XILINX_PART = xc3s400-pq208-4
 
 # set paths to Xilinx/Intel tools, adjust these for your environment
 mkpath = $(subst $(eval) ,:,$(wildcard $1))
-XILINX_HOME = /cygdrive/d/Xilinx/14.7/ISE_DS
 XILINX := $(XILINX_HOME)/ISE
-XILINX_BIN = $(XILINX_HOME)/ISE/bin/nt64
-XILINX_PATHS = ISE/bin/nt64 ISE/lib/nt64 PlanAhead/bin EDK/bin/nt64 EDK/lib/nt64
 XILINX_EDK := $(XILINX_HOME)/EDK
 XILINX_PLANAHEAD := $(XILINX_HOME)/PlanAhead
 XILINX_DSP := $(XILINX_HOME)/ISE
@@ -32,8 +29,6 @@ endif
 XILINX_CT = $(shell grep Cost.*Map sd2snes_$(CORE).xise | sed -e 's/.*value="\([0-9]\+\)".*$$/\1/g')
 XILINX_MAP_OPTS = -timing -logic_opt on -ol high -xe n -register_duplication on -cm area -ir off -pr b -power off
 XILINX_PAR_OPTS = -ol high -xe n
-
-INTEL_BIN = /cygdrive/d/intelFPGA_lite/18.1/quartus/bin64
 
 VSRC = address.v dcm.v main.v mcu_cmd.v spi.v
 VHSRC =
@@ -60,11 +55,11 @@ mk3: fpga_$(CORE).bi3
 # build mk2 using SmartXPlorer (useful for cx4, gsu, sa1, sdd1)
 mk2s: smartxplorer
 
-smartxplorer: main.ngc
+smartxplorer: main.ngd
 	rm -rf smartxplorer_results
 	PATH="$(XILINX_PATH)":"$(PATH)"; \
 	export XILINX="$(XILINX)" XILINX_DSP="$(XILINX_DSP)" XILINX_EDK="$(XILINX_EDK)" XILINX_PLANAHEAD="$(XILINX_PLANAHEAD)"; \
-	smartxplorer -sf currentProps.stratfile -p $(XILINX_PART) -b -wd smartxplorer_results main.ngd -to "-v 3 -s 4 -n 3 -fastpaths -xml main.twx -ucf main.ucf" -host_list hostlistfile.txt -max_runs 99 -best_n_runs 1 \
+	smartxplorer -p $(XILINX_PART) -b -wd smartxplorer_results main.ngd -to "-v 3 -s 4 -n 3 -fastpaths -xml main.twx -ucf main.ucf" $(XPLORER_PARAMS) \
 	&& (while true; do \
 		touch $@; \
 		export SX_RUN=`grep "Run index" smartxplorer_results/smartxplorer.log | sed -e 's/^.*\:.*run\([0-9]\+\).*$$/\1/g'`; \

--- a/verilog/sd2snes_obc1/Makefile
+++ b/verilog/sd2snes_obc1/Makefile
@@ -1,19 +1,16 @@
+include ../common.mk
 # This is a rather primitive Makefile to facilitate (re)compilation of the FPGA
 # core. It assumes that an initial project setup/compilation, particularly of
 # any IP cores used, has taken place using the vendor's corresponding FPGA
 # development environment.
 
 # build on Windows
-HOST = CYGWIN
 CORE = obc1
 XILINX_PART = xc3s400-pq208-4
 
 # set paths to Xilinx/Intel tools, adjust these for your environment
 mkpath = $(subst $(eval) ,:,$(wildcard $1))
-XILINX_HOME = /cygdrive/d/Xilinx/14.7/ISE_DS
 XILINX := $(XILINX_HOME)/ISE
-XILINX_BIN = $(XILINX_HOME)/ISE/bin/nt64
-XILINX_PATHS = ISE/bin/nt64 ISE/lib/nt64 PlanAhead/bin EDK/bin/nt64 EDK/lib/nt64
 XILINX_EDK := $(XILINX_HOME)/EDK
 XILINX_PLANAHEAD := $(XILINX_HOME)/PlanAhead
 XILINX_DSP := $(XILINX_HOME)/ISE
@@ -32,8 +29,6 @@ endif
 XILINX_CT = $(shell grep Cost.*Map sd2snes_$(CORE).xise | sed -e 's/.*value="\([0-9]\+\)".*$$/\1/g')
 XILINX_MAP_OPTS = -timing -logic_opt on -ol high -xe n -register_duplication on -cm area -ir off -pr b -power off
 XILINX_PAR_OPTS = -ol high -xe n
-
-INTEL_BIN = /cygdrive/d/intelFPGA_lite/18.1/quartus/bin64
 
 VSRC = address.v cheat.v clk_test.v dac.v dcm.v obc1.v main.v mcu_cmd.v msu.v sd_dma.v spi.v
 VHSRC =
@@ -60,7 +55,7 @@ mk3: fpga_$(CORE).bi3
 # build mk2 using SmartXPlorer (useful for cx4, gsu, sa1, sdd1)
 mk2s: smartxplorer
 
-smartxplorer: main.ngc
+smartxplorer: main.ngd
 	rm -rf smartxplorer_results
 	PATH="$(XILINX_PATH)":"$(PATH)"; \
 	export XILINX="$(XILINX)" XILINX_DSP="$(XILINX_DSP)" XILINX_EDK="$(XILINX_EDK)" XILINX_PLANAHEAD="$(XILINX_PLANAHEAD)"; \

--- a/verilog/sd2snes_sa1/Makefile
+++ b/verilog/sd2snes_sa1/Makefile
@@ -1,19 +1,16 @@
+include ../common.mk
 # This is a rather primitive Makefile to facilitate (re)compilation of the FPGA
 # core. It assumes that an initial project setup/compilation, particularly of
 # any IP cores used, has taken place using the vendor's corresponding FPGA
 # development environment.
 
 # build on Windows
-HOST = CYGWIN
 CORE = sa1
 XILINX_PART = xc3s400-pq208-4
 
 # set paths to Xilinx/Intel tools, adjust these for your environment
 mkpath = $(subst $(eval) ,:,$(wildcard $1))
-XILINX_HOME = /cygdrive/d/Xilinx/14.7/ISE_DS
 XILINX := $(XILINX_HOME)/ISE
-XILINX_BIN = $(XILINX_HOME)/ISE/bin/nt64
-XILINX_PATHS = ISE/bin/nt64 ISE/lib/nt64 PlanAhead/bin EDK/bin/nt64 EDK/lib/nt64
 XILINX_EDK := $(XILINX_HOME)/EDK
 XILINX_PLANAHEAD := $(XILINX_HOME)/PlanAhead
 XILINX_DSP := $(XILINX_HOME)/ISE
@@ -32,8 +29,6 @@ endif
 XILINX_CT = $(shell grep Cost.*Map sd2snes_$(CORE).xise | sed -e 's/.*value="\([0-9]\+\)".*$$/\1/g')
 XILINX_MAP_OPTS = -timing -logic_opt on -ol high -xe n -register_duplication on -cm area -ir off -pr b -power off
 XILINX_PAR_OPTS = -ol high -xe n
-
-INTEL_BIN = /cygdrive/d/intelFPGA_lite/18.1/quartus/bin64
 
 VSRC = address.v cheat.v clk_test.v dac.v dcm.v sa1.v main.v mcu_cmd.v msu.v sd_dma.v spi.v
 VHSRC =
@@ -60,11 +55,11 @@ mk3: fpga_$(CORE).bi3
 # build mk2 using SmartXPlorer (useful for cx4, gsu, sa1, sdd1)
 mk2s: smartxplorer
 
-smartxplorer: main.ngc
+smartxplorer: main.ngd
 	rm -rf smartxplorer_results
 	PATH="$(XILINX_PATH)":"$(PATH)"; \
 	export XILINX="$(XILINX)" XILINX_DSP="$(XILINX_DSP)" XILINX_EDK="$(XILINX_EDK)" XILINX_PLANAHEAD="$(XILINX_PLANAHEAD)"; \
-	smartxplorer -sf currentProps.stratfile -p $(XILINX_PART) -b -wd smartxplorer_results main.ngd -to "-v 3 -s 4 -n 3 -fastpaths -xml main.twx -ucf main.ucf" -host_list hostlistfile.txt -max_runs 99 -best_n_runs 1 \
+	smartxplorer -p $(XILINX_PART) -b -wd smartxplorer_results main.ngd -to "-v 3 -s 4 -n 3 -fastpaths -xml main.twx -ucf main.ucf" $(XPLORER_PARAMS) \
 	&& (while true; do \
 		touch $@; \
 		export SX_RUN=`grep "Run index" smartxplorer_results/smartxplorer.log | sed -e 's/^.*\:.*run\([0-9]\+\).*$$/\1/g'`; \

--- a/verilog/sd2snes_sdd1/Makefile
+++ b/verilog/sd2snes_sdd1/Makefile
@@ -1,19 +1,16 @@
+include ../common.mk
 # This is a rather primitive Makefile to facilitate (re)compilation of the FPGA
 # core. It assumes that an initial project setup/compilation, particularly of
 # any IP cores used, has taken place using the vendor's corresponding FPGA
 # development environment.
 
 # build on Windows
-HOST = CYGWIN
 CORE = sdd1
 XILINX_PART = xc3s400-pq208-4
 
 # set paths to Xilinx/Intel tools, adjust these for your environment
 mkpath = $(subst $(eval) ,:,$(wildcard $1))
-XILINX_HOME = /cygdrive/d/Xilinx/14.7/ISE_DS
 XILINX := $(XILINX_HOME)/ISE
-XILINX_BIN = $(XILINX_HOME)/ISE/bin/nt64
-XILINX_PATHS = ISE/bin/nt64 ISE/lib/nt64 PlanAhead/bin EDK/bin/nt64 EDK/lib/nt64
 XILINX_EDK := $(XILINX_HOME)/EDK
 XILINX_PLANAHEAD := $(XILINX_HOME)/PlanAhead
 XILINX_DSP := $(XILINX_HOME)/ISE
@@ -32,8 +29,6 @@ endif
 XILINX_CT = $(shell grep Cost.*Map sd2snes_$(CORE).xise | sed -e 's/.*value="\([0-9]\+\)".*$$/\1/g')
 XILINX_MAP_OPTS = -timing -logic_opt on -ol high -xe n -register_duplication on -cm area -ir off -pr b -power off
 XILINX_PAR_OPTS = -ol high -xe n
-
-INTEL_BIN = /cygdrive/d/intelFPGA_lite/18.1/quartus/bin64
 
 VSRC = address.v cheat.v clk_test.v dac.v DCM_Scope.v main.v mcu_cmd.v msu.v sd_dma.v spi.v
 VHSRC = FIFO_B2B.vhd FIFO_AXIS.vhd Golomb_0_Decoder.vhd Golomb_N_Decoder.vhd Input_Manager.vhd Output_Manager.vhd Probability_Estimator.vhd SDD1.vhd Serializer.vhd
@@ -60,11 +55,11 @@ mk3: fpga_$(CORE).bi3
 # build mk2 using SmartXPlorer (useful for cx4, gsu, sa1, sdd1)
 mk2s: smartxplorer
 
-smartxplorer: main.ngc
+smartxplorer: main.ngd
 	rm -rf smartxplorer_results
 	PATH="$(XILINX_PATH)":"$(PATH)"; \
 	export XILINX="$(XILINX)" XILINX_DSP="$(XILINX_DSP)" XILINX_EDK="$(XILINX_EDK)" XILINX_PLANAHEAD="$(XILINX_PLANAHEAD)"; \
-	smartxplorer -sf currentProps.stratfile -p $(XILINX_PART) -b -wd smartxplorer_results main.ngd -to "-v 3 -s 4 -n 3 -fastpaths -xml main.twx -ucf main.ucf" -host_list hostlistfile.txt -max_runs 99 -best_n_runs 1 \
+	smartxplorer -p $(XILINX_PART) -b -wd smartxplorer_results main.ngd -to "-v 3 -s 4 -n 3 -fastpaths -xml main.twx -ucf main.ucf" $(XPLORER_PARAMS) \
 	&& (while true; do \
 		touch $@; \
 		export SX_RUN=`grep "Run index" smartxplorer_results/smartxplorer.log | sed -e 's/^.*\:.*run\([0-9]\+\).*$$/\1/g'`; \


### PR DESCRIPTION
Fixes some of the issues in #123  by:

- Use common.mk file for configurations depending on host system
- Make smartxplorer depend on ngd instead of ngc
- Fix mem2lorom by adding include for types
- Add some files and directories to .gitignore to clean up

