### PR TITLE
Update MSU-1 Revision Number

### DIFF
--- a/verilog/sd2snes_base/msu.v
+++ b/verilog/sd2snes_base/msu.v
@@ -150,7 +150,7 @@ end
 always @(posedge clkin) begin
   if(reg_oe_falling & enable)
     case(reg_addr)
-      3'h0: data_out_r <= {data_busy_r, audio_busy_r, audio_status_r, audio_error_r, 3'b001};
+      3'h0: data_out_r <= {data_busy_r, audio_busy_r, audio_status_r, audio_error_r, 3'b010};
       3'h1: data_out_r <= msu_data;
       3'h2: data_out_r <= 8'h53;
       3'h3: data_out_r <= 8'h2d;


### PR DESCRIPTION
Per @qwertymodo, MSU-1 should be set to revision 2, as resume support was already added.  This will allow homebrew and hacks to properly detect that MSU-1 chip provided by the sd2snes has track resume support.

https://github.com/mrehkopf/sd2snes/pull/67

From qwertymodo in the Classic Gaming discord:

> Huh, can't believe I never realized that before. Super easy though, just change 3'b001 to 3'b002 here and recompile
> Resume support was the only change from rev 1 to rev 2, so updating the the reported rev is correct without any other changes necessary.