### PR TITLE
Build: Explicitly specify gawk instead of awk

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -148,7 +148,7 @@ SIZE = $(ARCH)-size
 NM = $(ARCH)-nm
 REMOVE = rm -f
 COPY = cp
-AWK = awk
+AWK = gawk
 BIN2C = ../utils/bin2c
 
 #---------------- Compiler Options ----------------

--- a/src/conf2h.awk
+++ b/src/conf2h.awk
@@ -1,4 +1,4 @@
-#! /usr/bin/gawk -f
+#!/usr/bin/gawk -f
 
 # Trivial little script to convert from a makefile-style configuration
 # file to a C header. No copyright claimed.


### PR DESCRIPTION
gawk features are used in the conf2h.awk. Fixes build on macos