### PR TITLE
Fix refresh/cursor issues in "Favorite games" menu

### DIFF
--- a/snes/data.a65
+++ b/snes/data.a65
@@ -95,10 +95,15 @@ listdisp        .word 0 ; number of displayable list entries
 ;-misc
 testvar         .word 0,0,0,0
 ;menu system
-listsel_sel     .byt 0
-listsel_step    .byt 0
-listsel_max     .byt 0
-listsel_pickbutton .byt 0
+listsel_sel         .byt 0
+listsel_step        .byt 0
+listsel_max         .byt 0
+listsel_pickbutton  .byt 0
+listsel_dirty       .byt 0
+listsel_backup      .byt 0
+
+screen_dma_disable  .word 0
+
 ;----------hdma tables in WRAM (must be stable when cartridge is cut off)
 hdma_pal
   .byt 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0

--- a/snes/filesel.a65
+++ b/snes/filesel.a65
@@ -1003,12 +1003,14 @@ select_favorite_file:
   php
   sep #$20 : .as
   rep #$10 : .xl
+  lda #$00
+  sta listsel_backup
+select_favorite_redraw:
   lda @ST_NUM_FAVORITE_GAMES
-  sta num_favorite_games
   bne +
-  plp
-  rtl
-+ lda #^text_favorite
+  jmp select_favorite_file_out
++ sta num_favorite_games
+  lda #^text_favorite
   sta window_tbank
   ldx #!text_favorite
   stx window_taddr
@@ -1023,13 +1025,19 @@ select_favorite_file:
   pha
   lda @last_win_w
   sta window_w
-  lda @ST_NUM_FAVORITE_GAMES
+  lda num_favorite_games
   inc
   inc
   sta window_h
   jsr push_window
   lda num_favorite_games
   sta listsel_max
+  dec ; listsel_max is an element count but listsel_sel is 0..max-1
+  cmp listsel_backup
+  bcs +
+  sta listsel_backup
++ lda listsel_backup
+  sta listsel_sel
   jsr draw_window
   stz print_pal
   lda #^FAVORITE_GAMES
@@ -1048,10 +1056,14 @@ select_favorite_file:
   inc print_y
   dec num_favorite_games
   bne -
+  stz listsel_dirty
+  jsr enable_screen_update
+select_favorite_choose:
   lda #$01
   sta listsel_step
-  sta listsel_pickbutton
-  jsr menu_select
+  sta listsel_pickbutton ; allow button Y
+  jsr menu_select_noinit
+  sta listsel_backup
   sta @MCU_PARAM ; store selected item index in mcu param
   cmp #$ff ; if no selected item, do nothing
   beq select_favorite_file_done
@@ -1068,11 +1080,17 @@ select_favorite_file_play
   bra select_favorite_file_done
 select_favorite_file_context_menu
   jsr filesel_favorites_contextmenu
+  lda listsel_dirty          ; need redraw?
+  bne +
+  jmp select_favorite_choose ; return to previous view
++ stz listsel_dirty
   jsr pop_window
-  plp
-  jmp select_favorite_file ; return to favorite list after closing the ctx menu
+  jsr disable_screen_update
+  jmp select_favorite_redraw   ; redraw favorite list
 select_favorite_file_done
   jsr pop_window
+select_favorite_file_out
+  jsr enable_screen_update
   plp
   rtl
 
@@ -1102,6 +1120,7 @@ remove_selected_favorite_file:
   bra -
   + lda #$55
   sta @MCU_CMD
+  sta listsel_dirty
   jsr pop_window
   plb
   plp

--- a/snes/main.a65
+++ b/snes/main.a65
@@ -308,6 +308,8 @@ video_init:
   stz fade_count
   stz idle_count
   stz idle_count+1
+  stz screen_dma_disable
+  stz screen_dma_disable+1
   rts
 
 screen_on:

--- a/snes/reset.a65
+++ b/snes/reset.a65
@@ -9,6 +9,8 @@ NMI_ROUTINE:
   lda #$00
   pha
   plb
+  lda screen_dma_disable
+  bne +
   ldx #BG1_TILE_BASE+32*9
   stx $2116
   DMA7(#$01, #40*64, #^BG1_TILE_BUF, #!BG1_TILE_BUF+64*9, #$18)
@@ -20,7 +22,7 @@ NMI_ROUTINE:
   ldx #BG2_TILE_BASE
   stx $2116
   DMA7(#$01, #64*9, #^BG2_TILE_BUF, #!BG2_TILE_BUF, #$18)
-
++
   lda bar_yl
   dec
   asl

--- a/snes/ui.a65
+++ b/snes/ui.a65
@@ -697,3 +697,13 @@ set_bar_color:
     sta @hdma_math+11
   plp
   rts
+
+; disable screen update (DMA from WRAM to VRAM)
+disable_screen_update:
+  inc screen_dma_disable
+  rts
+
+; enable screen update (DMA from WRAM to VRAM)
+enable_screen_update:
+  stz screen_dma_disable
+  rts


### PR DESCRIPTION
Fixes #156

UI stuff is always the most painful...
- There was no way to return outside of the submenu system whether a
  function was executed so a `listsel_dirty` flag was introduced to force
  refresh
- Same for the `listsel_backup` variable to keep track of the selected list
  item before entering the submenu
- Redrawing the list after removing a favorite resulted in some flickering so
  an additional `screen_dma_disable` flag was introduced to inhibit
  screen refresh (WRAM->VRAM DMA) until the redraw was finished.
  This feature can be useful for other redraw operations.