### PR TITLE
Added CCNT_RDYB (wait bit) implementation.

### DIFF
--- a/verilog/sd2snes_sa1/sa1.v
+++ b/verilog/sd2snes_sa1/sa1.v
@@ -2546,9 +2546,12 @@ always @(posedge CLK) begin
   else begin
     case (EXE_STATE)
       ST_EXE_IDLE: begin
-        if (~CCNT_r[`CCNT_SA1_RESB] & sa1_clock_en) begin
+        if (CCNT_r[`CCNT_SA1_RESB]) begin
           {PBR_r,PC_r} <= {8'h00,CRV_r};
           exe_fetch_addr_r <= {8'h00,CRV_r};
+        end
+
+        if (~(CCNT_r[`CCNT_SA1_RESB] | CCNT_r[`CCNT_SA1_RDYB]) & sa1_clock_en) begin
           exe_fetch_size_r <= 0;
           exe_mmc_byte_total_r <= 1;
           exe_data_word_r <= 0;
@@ -3208,7 +3211,7 @@ always @(posedge CLK) begin
           // reset internal PCs to help with debugging
           exe_nextpc_r   <= 0;
 
-          EXE_STATE <= (exe_active_r & ~CCNT_r[`CCNT_SA1_RESB]) ? ST_EXE_FETCH : ST_EXE_IDLE;
+          EXE_STATE <= (exe_active_r & ~(CCNT_r[`CCNT_SA1_RESB] | CCNT_r[`CCNT_SA1_RDYB])) ? ST_EXE_FETCH : ST_EXE_IDLE;
         end
       end
     endcase


### PR DESCRIPTION
This is a simple change to halt SA-1 instruction execute when someone writes bit $40 of the CCNT register.  The SA-1 resumes where it left off instead of taking the reset vector such as when bit $20 is used.  Since no commercial game uses this bit, it was tested by putting the SA-1 in a spin loop that increments a BW-RAM variable while the S-CPU writes either halted (CCNT=$40) or active (CCNT=$00) to CCNT.  Other state machines may still be active in the SA-1 and it is expected that the user makes sure they are in a legal state, e.g. IDLE, when using this bit.