### PR TITLE
fix: string termination for character format

### DIFF
--- a/src/printf.c
+++ b/src/printf.c
@@ -150,6 +150,7 @@ static int internal_nprintf(void (*output_function)(char c), const char *fmt, va
       switch (*fmt) {
       case 'c':
         buffer[0] = va_arg(ap, int);
+        buffer[1] = 0;
         ptr = buffer;
         break;
 


### PR DESCRIPTION
Temp string was not zero-terminated after writing the character when using the %c format specifier, leading to extra characters being printed.