### PR TITLE
Fix-hdma-INIDISP-SCPU-B-silicon-bug

### DIFF
--- a/snes/msu1/const.a65
+++ b/snes/msu1/const.a65
@@ -1,3 +1,4 @@
+.link page $c0
 zero		.word 0
 ; hdma_blank: write to $21ff-$2100 once (mode 1)
 ; [specific workaround for S-CPU B DMA silicon bug]

--- a/snes/msu1/const.a65
+++ b/snes/msu1/const.a65
@@ -1,15 +1,16 @@
 zero		.word 0
-; hdma_blank: write to $2100 once (mode 0)
+; hdma_blank: write to $21ff-$2100 once (mode 1)
+; [specific workaround for S-CPU B DMA silicon bug]
 ; force blanking up to line 40 and from line 184
 ; (active display = 144 lines)
 hdma_blank	.byt 40
-		.byt $8f
+		.byt $8f, $8f
 		.byt 127
-		.byt $0f
+		.byt $0f, $0f
 		.byt 17
-		.byt $0f
+		.byt $0f, $0f
 		.byt 1
-		.byt $8f
+		.byt $8f, $8f
 		.byt 0
 
 ; h/vscroll: write to $210d twice, write to $210e twice (mode 3)

--- a/snes/msu1/data.a65
+++ b/snes/msu1/data.a65
@@ -1,5 +1,6 @@
 *=$7E0000
 .data
+.link page $7e
 
 dispcnt		.byt 0
 

--- a/snes/msu1/dma.a65
+++ b/snes/msu1/dma.a65
@@ -40,10 +40,14 @@ setup_hdma:
 	sty $4322
 	sta $4324
 
-; BLANKING CHANNEL MUST NOT BE A DIRECT NEIGHBOUR OF THE GPDMA CHANNEL.
-	lda #$00		;A to B; direct; 1x single reg
+; HDMA to $2100 is verboten (S-CPU B silicon bug makes it drop GPDMA transfers)
+; It's not the transfer itself but the fact that $43x1 somehow must not contain
+; zero.  So we setup HDMA to $21ff, make it write two B-bus regs and let it wrap
+; around to $2100 this way.
+
+	lda #$01		;A to B; direct; Mode 1: 1x 2 regs
 	sta $4330		;ch. 3 for blanking
-	lda #$00		;2100 = inidisp
+	lda #$ff		;2100 = inidisp
 	sta $4331
 	lda #^hdma_blank
 	ldy #!hdma_blank

--- a/snes/msu1/dma.a65
+++ b/snes/msu1/dma.a65
@@ -1,3 +1,4 @@
+.link page $c0
 
 dma0:
 	rep #$10 : .xl

--- a/snes/msu1/header.a65
+++ b/snes/msu1/header.a65
@@ -64,7 +64,7 @@ NMI_8bit:
 *= $C0FFD6     .byt $02  ;rom type
 *= $C0FFD7     .byt $06  ;rom size   64 kByte
 *= $C0FFD8     .byt $03  ;sram size  8 kBit
-*= $C0FFD9     .byt $09  ;rom region 4 = Finland
+*= $C0FFD9     .byt $00  ;rom region 0 = Japan/NTSC (player wants 60Hz)
 *= $C0FFDA     .byt $33  ;company id flag
 
 *= $C0FFDC     .word 0,0 ;checksums

--- a/snes/msu1/main.a65
+++ b/snes/msu1/main.a65
@@ -1,3 +1,5 @@
+.link page $c0
+
 #include "dma.i65"
 
 GAME_MAIN:

--- a/snes/msu1/msu1.a65
+++ b/snes/msu1/msu1.a65
@@ -1,3 +1,5 @@
+.link page $c0
+
 #include "dma.i65"
 #include "msu1.i65"
 

--- a/snes/msu1/reset.a65
+++ b/snes/msu1/reset.a65
@@ -1,6 +1,8 @@
 ; This file is part of the snescom-asm demo - a demo of how to build a SNES program.
 ; See http://bisqwit.iki.fi/source/snescom.html for details.
 
+.link page $c0
+
 #include "dma.i65"
 
 #define TILE_ADDR_REG_VAL(addr, scsize) \

--- a/snes/msu1/spc.a65
+++ b/snes/msu1/spc.a65
@@ -1,3 +1,5 @@
+.link page $c0
+
 spc_upload:
 	rep #$20 : .al
 	sep #$10 : .xs


### PR DESCRIPTION
Workaround S-CPU B DMA silicon bug

The SNES's CPU revision B occasionally does not carry out DMA transfers when a HDMA channel is configured to use $2100 as a B-Bus target, i.e. $00 must not be written to any DMA channel's B-Bus address register at any time.
The fix sets $21ff (unmapped) as a target address instead and configures the DMA channel to write two registers, thereby wrapping around to $2100 on the second write.