### PR TITLE
Fixed CTX DMA write snoops in CT by blocking concurrent PARD assertion.

### DIFF
--- a/verilog/sd2snes_base/main.v
+++ b/verilog/sd2snes_base/main.v
@@ -333,7 +333,8 @@ always @(posedge CLK2) begin
   end
 
   // count of write low
-  if (SNES_reset_strobe | SNES_SNOOPPARD_end) begin
+  // prioritize writes when there is a DMA from a PPU reg
+  if (SNES_reset_strobe | SNES_SNOOPPARD_end | ~SNES_WRITE) begin
     SNES_SNOOPPARD_count <= 0;
     SNES_SNOOPPARD_DATA_OE <= 0;
   end


### PR DESCRIPTION
Chrono Trigger uses the PPU $2134 register as a source to zero out WRAM using a DMA. The CTX state machine captures the WRAM write then immediately overwrites the shadow address with the PPU register. This means we lose the zeroing of WRAM in the save state. These locations for WRAM are used for indirect HDMA source data to PPU registers which causes graphics to mess up when the save state is loaded. I'm sure this isn't the only game which does this kind of DMA so hopefully others are working now, too. The fix blocks the PARD snoop when there is a write.