### PR TITLE
Fixes related to MSU1 autosave

### DIFF
--- a/snes/const.a65
+++ b/snes/const.a65
@@ -230,6 +230,8 @@ mtext_ingame_regionpatch          .byt "Auto region patch", 0
 mtext_ingame_1chiptransientfixes  .byt "1CHIP transient fixes", 0
 mtext_ingame_brightlimit          .byt "Brightness limit", 0
 mtext_ingame_resetpatch           .byt "Reset patch for clock phase", 0
+mtext_ingame_autosave             .byt "Autosave", 0
+mtext_ingame_autosave_msu1        .byt " ",129,"MSU-1 Autosave", 0
 mtext_chip_cx4_speed              .byt "Cx4 speed", 0
 mtext_chip_gsu_speed              .byt "SuperFX speed", 0
 mtext_chip_msu1_volume_boost      .byt "MSU-1 volume boost", 0
@@ -275,6 +277,8 @@ mdesc_ingame_regionpatch          .byt "Bypass simple region protection by games
 mdesc_ingame_1chiptransientfixes  .byt "Patch brightness changes to fix sync glitches, fading scanlines and missing shadow on 1CHIP/Jr. consoles", 0
 mdesc_ingame_brightlimit          .byt "Limit overall brightness (e.g. on 1CHIP consoles to meet RGB line levels)", 0
 mdesc_ingame_resetpatch           .byt "Enable reset patch to align clocks.  Fixes graphical issues in some games", 0
+mdesc_ingame_autosave             .byt "Automatically save SRM file when Save RAM contents change", 0
+mdesc_ingame_autosave_msu1        .byt "MSU-1: Take some opportunities to auto-save SRM file. May cause brief stuttering.", 0
 mdesc_chip_cx4_speed              .byt "Set speed of Cx4 soft core", 0
 mdesc_chip_gsu_speed              .byt "Set speed of SuperFX soft core", 0
 mdesc_chip_msu1_volume_boost      .byt "Set volume boost for MSU1 audio if your sd2snes is too quiet (Rev. E-G)", 0

--- a/snes/memmap.i65
+++ b/snes/memmap.i65
@@ -132,6 +132,8 @@
 #define CFG_SGB_CLOCK_FIX               CFG_ADDR+$00B1
 #define CFG_SGB_BIOS_VERSION            CFG_ADDR+$00B2
 #define CFG_SHOW_TRIBUTE                CFG_ADDR+$00B3
+#define CFG_ENABLE_AUTOSAVE             CFG_ADDR+$00B4
+#define CFG_ENABLE_AUTOSAVE_MSU1        CFG_ADDR+$00B5
 
 #define MENU_ENTRY_SIZE             23
 

--- a/snes/menudata.a65
+++ b/snes/menudata.a65
@@ -13,6 +13,7 @@
 ; 1 byte   data type of parameter (see below)
 ; 3 bytes  long pointer to parameter value (of data type above)
 ; 3 bytes  long pointer to text description of item
+; Function pointers: (address - 1!)
 ; 3 bytes  long pointer to change-hook function (called whenever the value is changed during selection; no return value)
 ; 3 bytes  long pointer to post-hook function (called when the value is set; no return value)
 ; 3 bytes  long pointer to isEnabled function (return: c=0: enabled, c=1: disabled)
@@ -509,6 +510,35 @@ menu_enttab_ingame:
 ; ENTRIES
 
  .byt  MTYPE_VALUE
+ .word !mtext_ingame_autosave
+ .byt  ^mtext_ingame_autosave
+ .word !kv_onoff
+ .byt  ^kv_onoff
+ .byt  OPTTYPE_KVBYTE
+ .word !CFG_ENABLE_AUTOSAVE
+ .byt  ^CFG_ENABLE_AUTOSAVE
+ .word !mdesc_ingame_autosave
+ .byt  ^mdesc_ingame_autosave
+ .byt  0,0,0
+ .byt  0,0,0
+ .byt  0,0,0
+
+ .byt  MTYPE_VALUE
+ .word !mtext_ingame_autosave_msu1
+ .byt  ^mtext_ingame_autosave_msu1
+ .word !kv_onoff
+ .byt  ^kv_onoff
+ .byt  OPTTYPE_KVBYTE
+ .word !CFG_ENABLE_AUTOSAVE_MSU1
+ .byt  ^CFG_ENABLE_AUTOSAVE_MSU1
+ .word !mdesc_ingame_autosave_msu1
+ .byt  ^mdesc_ingame_autosave_msu1
+ .byt  0,0,0
+ .byt  0,0,0
+ .word !(mfunc_isenabled_autosave-1)
+ .byt  ^(mfunc_isenabled_autosave-1)
+
+ .byt  MTYPE_VALUE
  .word !mtext_ingame_cheats
  .byt  ^mtext_ingame_cheats
  .word !kv_yesno
@@ -828,6 +858,12 @@ mfunc_isenabled_savestate:
 mfunc_isenabled_scic:
   lda @CFG_PAIR_MODE_ALLOWED
   and @ST_PAIRMODE
+  eor #$ff
+  ror
+  rtl
+
+mfunc_isenabled_autosave:
+  lda @CFG_ENABLE_AUTOSAVE
   eor #$ff
   ror
   rtl

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -47,7 +47,9 @@ cfg_t CFG_DEFAULT = {
   .sgb_enh_override = 0,
   .sgb_clock_fix = 1,
   .sgb_bios_version = 2,
-  .show_tribute = 1
+  .show_tribute = 1,
+  .enable_autosave = 1,
+  .enable_autosave_msu1 = 1
 };
 
 cfg_t CFG;
@@ -146,6 +148,11 @@ int cfg_save() {
   f_printf(&file_handle, "%s: %d\n", CFG_MSU_VOLUME_BOOST, CFG.msu_volume_boost);
   f_puts("\n# Show Near memorial screen (only in 1.11.0)\n", &file_handle);
   f_printf(&file_handle, "%s: %d\n", CFG_SHOW_TRIBUTE, CFG.show_tribute);
+  f_puts("\n# Autosave (save SRAM contents to card when changes are detected)\n", &file_handle);
+  f_printf(&file_handle, "#  %s: Autosave for everything except MSU-1 games\n", CFG_ENABLE_AUTOSAVE);
+  f_printf(&file_handle, "%s: %s\n", CFG_ENABLE_AUTOSAVE, CFG.enable_autosave ? "true" : "false");
+  f_printf(&file_handle, "#  %s: Opportunistic Autosave for MSU-1 games\n", CFG_ENABLE_AUTOSAVE_MSU1);
+  f_printf(&file_handle, "%s: %s\n", CFG_ENABLE_AUTOSAVE_MSU1, CFG.enable_autosave_msu1 ? "true" : "false");
   file_close();
   return err;
 }
@@ -272,6 +279,12 @@ int cfg_load() {
     if(yaml_get_itemvalue(CFG_SHOW_TRIBUTE, &tok)) {
       CFG.show_tribute = tok.longvalue;
       printf("show_tribute is %d\n", CFG.show_tribute);
+    }
+    if(yaml_get_itemvalue(CFG_ENABLE_AUTOSAVE, &tok)) {
+      CFG.enable_autosave = tok.boolvalue ? 1 : 0;
+    }
+    if(yaml_get_itemvalue(CFG_ENABLE_AUTOSAVE_MSU1, &tok)) {
+      CFG.enable_autosave_msu1 = tok.boolvalue ? 1 : 0;
     }
   }
   yaml_file_close();
@@ -597,4 +610,8 @@ uint16_t cfg_buttons_string2bits(char *str) {
   }
 //  printf("converted button string %s to bits: %04X\n", str, input);
   return input;
+}
+
+uint8_t cfg_is_msu1_autosave_enabled() {
+  return CFG.enable_autosave && CFG.enable_autosave_msu1;
 }

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -48,6 +48,9 @@
 #define CFG_SGB_CLOCK_FIX                ("SGBClockFix")
 #define CFG_SGB_BIOS_VERSION             ("SGBBiosVersion")
 #define CFG_SHOW_TRIBUTE                 ("ShowTribute")
+#define CFG_ENABLE_AUTOSAVE              ("EnableAutoSave")
+#define CFG_ENABLE_AUTOSAVE_MSU1         ("EnableMSU1AutoSave")
+
 typedef enum {
   VIDMODE_60 = 0,
   VIDMODE_50,
@@ -93,6 +96,8 @@ typedef struct __attribute__ ((__packed__)) _cfg_block {
   uint8_t  sgb_clock_fix;           /* SGB timing/clock (true: original/sgb2, false: snes/sgb1) */
   uint8_t  sgb_bios_version;        /* SGB bios firmware version (defined number loads: sgbX_boot.bin and sgbX_snes.bin) */
   uint8_t  show_tribute;
+  uint8_t  enable_autosave;         /* enable automatic saving when SRAM contents change */
+  uint8_t  enable_autosave_msu1;    /* enable opportunistic auto saving when SRAM contents change for MSU1 games */
 } cfg_t;
 
 int cfg_save(void);
@@ -138,5 +143,7 @@ uint8_t cfg_is_reset_to_menu(void);
 
 void cfg_buttons_bits2string(uint16_t bits, char *out);
 uint16_t cfg_buttons_string2bits(char *str);
+
+uint8_t cfg_is_msu1_autosave_enabled(void);
 
 #endif

--- a/src/msu1.c
+++ b/src/msu1.c
@@ -96,7 +96,7 @@ void prepare_audio_track(uint16_t msu_track, uint32_t audio_offset) {
   f_close(&msuaudio);
   msu_audio_usage = MSU_IDLE;
   if(is_msu_free_to_save()) {
-    msu_savecheck(1);
+    msu_savecheck(0);
   }
   snprintf(suffix, sizeof(suffix), "-%d.pcm", msu_track);
   strcpy((char*)file_buf, (char*)file_lfn);

--- a/src/msu1.c
+++ b/src/msu1.c
@@ -92,6 +92,7 @@ void prepare_audio_track(uint16_t msu_track, uint32_t audio_offset) {
   DBG_MSU1 printf("offset=%08lx sect=%08lx sample=%08lx\n", audio_offset, audio_sect, audio_sect_offset_sample);
   /* open file, fill buffer */
   char suffix[11];
+  dac_pause();
   f_close(&msuaudio);
   msu_audio_usage = MSU_IDLE;
   if(is_msu_free_to_save()) {
@@ -101,7 +102,6 @@ void prepare_audio_track(uint16_t msu_track, uint32_t audio_offset) {
   strcpy((char*)file_buf, (char*)file_lfn);
   strcpy(strrchr((char*)file_buf, (int)'.'), suffix);
   DBG_MSU1 printf("filename: %s\n", file_buf);
-  dac_pause();
   dac_reset(audio_sect_offset_sample);
   set_msu_status(MSU_SNES_STATUS_CLEAR_AUDIO_PLAY | MSU_SNES_STATUS_CLEAR_AUDIO_REPEAT);
   if(f_open(&msuaudio, (const TCHAR*)file_buf, FA_READ) == FR_OK) {

--- a/src/snes.c
+++ b/src/snes.c
@@ -289,7 +289,7 @@ uint8_t snes_main_loop() {
   /* save the GB RTC if enabled */
   sgb_gtc_save(file_lfn);
 
-  if(romprops.sramsize_bytes) {
+  if(romprops.sramsize_bytes && CFG.enable_autosave) {
     uint32_t crc_bytes = min(romprops.sramsize_bytes - saveram_offset, SRAM_REGION_SIZE);
     saveram_crc = calc_sram_crc(SRAM_SAVE_ADDR + romprops.srambase + saveram_offset, crc_bytes, saveram_crc);
     saveram_offset += crc_bytes;
@@ -336,8 +336,7 @@ uint8_t snes_main_loop() {
         saveram_crc = 0;
       }
     }
-  }
-  else {
+  } else {
     diffcount = 0;
     samecount = 0;
     didnotsave = 0;


### PR DESCRIPTION
### MSU1: speed up bulk PCM file scanning by some games

Some games, notably ALTTP Randomizer, perform a full scan of all PCM tracks on startup. After adding MSU1 SRAM checks, this led to a full SRAM check per track scanned (because it was considered a safe opportunity to always do an SRAM check on track change), resulting in 7+ seconds of one-time startup time for the game which was considered unacceptable.
SRAM check is now relaxed to at most once per second on track change; startup time is reduced to about 600ms.


### Add config toggles for Autosave & MSU1 Autosave

Since MSU1 auto saving may lead to undesired delays on track changes for quirky hacks, add a config option to turn it off.
In the process, a global autosave disable option is also introduced.
MSU1 autosave is automatically disabled when global autosave is disabled.


### Avoid static buzzing noise on MSU1 track change

Some games do not pause playback before changing the audio track. Normally this is not a problem since the track change handling stops playback implicitly; however after adding MSU1 SRAM checks the playback stop had moved after the SRAM check so there was an opportunity for the FPGA continuing playback without refilling the audio buffer.
Playback is now stopped before performing the SRAM check on track change.