### PR TITLE
Fixed SGB RTC by adding dummy write to account for data buffer.

### DIFF
--- a/src/fpga_spi.c
+++ b/src/fpga_spi.c
@@ -367,6 +367,7 @@ void set_bsx_regs(uint8_t set, uint8_t reset) {
 uint64_t get_fpga_time() {
   FPGA_SELECT();
   FPGA_TX_BYTE(FPGA_CMD_RTCGET);
+  FPGA_TX_BYTE(0x00); /* dummy (copy current ftime to register) */
   uint64_t result = ((uint64_t)FPGA_RX_BYTE()) << 48;
   result |= ((uint64_t)FPGA_RX_BYTE()) << 40;
   result |= ((uint64_t)FPGA_RX_BYTE()) << 32;

--- a/src/sgb.c
+++ b/src/sgb.c
@@ -412,7 +412,7 @@ void sgb_gtc_load(uint8_t* filename) {
 
     unsigned ftimel = (ftime >>  0) & 0xFFFFFFFF;
     unsigned ftimeh = (ftime >> 32) & 0xFFFFFFFF;
-    printf("SGB load GB RTC: days=%ld, hour=%hhd, min=%hhd, sec=%hhd, ftime=0x%04x%04x\n", gtime_cur.gtm_days,
+    printf("SGB load GB RTC: days=%ld, hour=%hhd, min=%hhd, sec=%hhd, ftime=0x%08x%08x\n", gtime_cur.gtm_days,
       gtime_cur.gtm_hour,
       gtime_cur.gtm_min,
       gtime_cur.gtm_sec,
@@ -459,7 +459,7 @@ void sgb_gtc_save(uint8_t* filename) {
 
       unsigned ftimel = (ftime >>  0) & 0xFFFFFFFF;
       unsigned ftimeh = (ftime >> 32) & 0xFFFFFFFF;
-      printf("SGB save GB RTC: days=%ld, hour=%hhd, min=%hhd, sec=%hhd, ftime=0x%04x%04x\n", gtime_cur.gtm_days,
+      printf("SGB save GB RTC: days=%ld, hour=%hhd, min=%hhd, sec=%hhd, ftime=0x%08x%08x\n", gtime_cur.gtm_days,
         gtime_cur.gtm_hour,
         gtime_cur.gtm_min,
         gtime_cur.gtm_sec,


### PR DESCRIPTION
The RTC data is put in a register during cycle 1 for spi reads which required a dummy write in the firmware.  I must have broken this when fixing timing.  The debug print of ftime was also fixed to include the correct number of digits.