### PR TITLE
feat: Add autoboot ROM support

### DIFF
--- a/snes/const.a65
+++ b/snes/const.a65
@@ -291,8 +291,14 @@ text_filesel_selected_file .byt "Selected file", 0
 text_filesel_context_add_to_favorites .byt "Add to favorites", 0
 mdesc_filesel_context_add_to_favorites .byt "Add the selected file to favorites", 0
 
+text_filesel_context_set_as_autoboot .byt "Set as autoboot", 0
+mdesc_filesel_context_set_as_autoboot .byt "Boot this ROM automatically on next power-on (hold START to cancel)", 0
+
 text_filesel_favorites_context_remove_from_favorites .byt "Remove from favorites", 0
 mdesc_filesel_favorites_context_remove_from_favorites .byt "Remove the selected file from favorites", 0
+
+text_filesel_favorites_context_set_as_autoboot .byt "Set as autoboot", 0
+mdesc_filesel_favorites_context_set_as_autoboot .byt "Boot this ROM automatically on next power-on (hold START to cancel)", 0
 
 text_statusbar_play .byt "A:Play B:Back X:Menu", 0
 text_statusbar_keys .byt "A:Select B:Back X:Menu Y:Context", 0

--- a/snes/data.a65
+++ b/snes/data.a65
@@ -223,7 +223,7 @@ current_dir
 infloop         .byt 0,0  ; to be filled w/ 80 FE
 tgt_bright      .byt 0
 cur_bright      .byt 0
-bright_limit    .byt 0
+menu_brightness .byt 0
 ;-- pad
 pad_b           .byt 0
 pad_y           .byt 0

--- a/snes/filesel.a65
+++ b/snes/filesel.a65
@@ -1126,6 +1126,68 @@ remove_selected_favorite_file:
   plp
   rtl
 
+set_selected_as_autoboot_rom:
+; have MCU save the currently selected file as the autoboot ROM
+; the file path should already have been saved to MCU_PARAM before calling
+; this routine (done by open_context_menu / ctx_is_file)
+  php
+  phb
+  sep #$20 : .as
+  lda #$01
+  jsr hide_cursor
+  jsr draw_loading_window
+  jsr waitblank
+  lda #$00
+  sta @SNES_CMD
+  lda #CMD_SET_AUTOBOOT_ROM
+  sta @MCU_CMD
+; wait for ACK/NACK
+- lda @SNES_CMD
+  cmp #$55
+; success
+  beq +
+  cmp #$aa
+; failure
+  beq +
+  bra -
++ lda #$55
+  sta @MCU_CMD
+  jsr pop_window
+  plb
+  plp
+  rtl
+
+set_favorite_as_autoboot_rom:
+; have MCU save the selected favorite game as the autoboot ROM
+; the list index of the favorite should already have been saved to MCU_PARAM
+; before calling this routine (done by select_favorite_file)
+  php
+  phb
+  sep #$20 : .as
+  lda #$01
+  jsr hide_cursor
+  jsr draw_loading_window
+  jsr waitblank
+  lda #$00
+  sta @SNES_CMD
+  lda #CMD_SET_AUTOBOOT_FAV
+  sta @MCU_CMD
+; wait for ACK/NACK
+- lda @SNES_CMD
+  cmp #$55
+; success
+  beq +
+  cmp #$aa
+; failure
+  beq +
+  bra -
++ lda #$55
+  sta @MCU_CMD
+  jsr pop_window
+  plb
+  plp
+  rtl
+
 scroll_direntry_clean:
   lda #$01
   sta direntry_xscroll_state

--- a/snes/main.a65
+++ b/snes/main.a65
@@ -719,6 +719,10 @@ clr_autoboot_at_boot:
   bra -
 + lda #$55
   sta @MCU_CMD
+; pretend START button had already been pressed so subsequent read_pads don't
+; detect a START press
+  lda #$10
+  sta pad1mem+1
   plp
   rts
 

--- a/snes/main.a65
+++ b/snes/main.a65
@@ -672,7 +672,6 @@ wait_mcu_ready:
 
 ; autoboot_cmd_handshake: send CMD_LOAD_AUTOBOOT to MCU and wait for response.
 ; return to menu if autoboot ROM loading fails (e.g. file not found)
-; NOTE: do NOT call WRAM_ROUTINE here — MCU uses LOADROM_WITH_RESET only.
 autoboot_cmd_handshake:
   php
   sep #$20 : .as
@@ -684,10 +683,12 @@ autoboot_cmd_handshake:
   cmp #$55
   beq +
   cmp #$aa
-  beq +
+  beq autoboot_cmd_handshake_error
   bra -
 + lda #$55
   sta @MCU_CMD
+  jsl @WRAM_ROUTINE
+autoboot_cmd_handshake_error:
   plp
   rts
 

--- a/snes/main.a65
+++ b/snes/main.a65
@@ -681,12 +681,7 @@ wait_mcu_ready:
 ; NOTE: do NOT call WRAM_ROUTINE here — MCU uses LOADROM_WITH_RESET only.
 autoboot_cmd_handshake:
   php
-  phb
   sep #$20 : .as
-  lda #$01
-  jsr hide_cursor
-  jsr draw_loading_window
-  jsr waitblank
   lda #$00
   sta @SNES_CMD
   lda #CMD_LOAD_AUTOBOOT
@@ -699,8 +694,6 @@ autoboot_cmd_handshake:
   bra -
 + lda #$55
   sta @MCU_CMD
-  jsr pop_window
-  plb
   plp
   rts
 
@@ -709,12 +702,7 @@ autoboot_cmd_handshake:
 ; Does NOT load a ROM; returns so the normal menu loop can proceed.
 clr_autoboot_at_boot:
   php
-  phb
   sep #$20 : .as
-  lda #$01
-  jsr hide_cursor
-  jsr draw_loading_window
-  jsr waitblank
   lda #$00
   sta @SNES_CMD
   lda #CMD_CLR_AUTOBOOT_ROM
@@ -727,8 +715,6 @@ clr_autoboot_at_boot:
   bra -
 + lda #$55
   sta @MCU_CMD
-  jsr pop_window
-  plb
   plp
   rts
 

--- a/snes/main.a65
+++ b/snes/main.a65
@@ -347,7 +347,7 @@ screen_on:
   stz $2100     ; screen on, 0% brightness
   lda @CFG_BRIGHTNESS_LIMIT
   sta tgt_bright
-  sta bright_limit
+  sta menu_brightness
   rts
 
 snes_init:

--- a/snes/main.a65
+++ b/snes/main.a65
@@ -82,15 +82,13 @@ coldboot:       ; Regular, cold-start init
   jsr setup_hdma
   jsr detect_ultra16
   jsr detect_satellaview
-  jsr screen_on
   jsr wait_mcu_ready
-  jsr filesel_init
-  sep #$20 : .as
-  lda @ST_RTC_VALID
-  beq +
-  jsl rtc_init
-+
-  ; Check if an autoboot ROM is configured
+  ; Check if an autoboot ROM is configured.
+  ; Screen is still in force-blank ($2100=$8f from snes_init) — no menu is
+  ; visible yet.  If autoboot fires successfully the MCU hardware-resets the
+  ; SNES and we never return, so the user sees no menu flash at all.
+  ; Only if no autoboot is set, START is held, or the ROM can't be loaded do
+  ; we fall through to the normal screen_on / filesel_init path below.
   sep #$20 : .as
   lda @ST_AUTOBOOT_ENABLED
   beq coldboot_autoboot_out       ; no autoboot configured
@@ -116,6 +114,13 @@ coldboot_bypass_autoboot:
   ; START was held: clear autoboot for future boots and show menu
   jsr clr_autoboot_at_boot
 coldboot_autoboot_out:
+  jsr screen_on
+  jsr filesel_init
+  sep #$20 : .as
+  lda @ST_RTC_VALID
+  beq +
+  jsl rtc_init
++
   jsr fileselloop
   sei
   stz $4200

--- a/snes/main.a65
+++ b/snes/main.a65
@@ -102,12 +102,11 @@ coldboot:       ; Regular, cold-start init
   ldx #60
 autoboot_start_poll:
   jsr waitblank         ; sync to VBlank boundary (NMI fires here, sets isr_done)
-- lda @$004212          ; HVBJOY: bit 0 = auto-joypad read in progress
-  and #$01
-  bne -                 ; wait until auto-read is done
-  lda @$004219          ; joypad 1 high byte: B,Y,SEL,STA,UP,DN,L,R
-  and #$10              ; bit 4 = START
-  bne coldboot_bypass_autoboot    ; START held -> bypass autoboot
+  phx
+    jsr read_pad
+  plx
+  lda pad_start         ; TODO possibly use configurable button combo here
+  bne coldboot_bypass_autoboot    ; START pressed -> bypass autoboot
   dex
   bne autoboot_start_poll
   ; START not held after ~1 second: trigger autoboot
@@ -719,10 +718,6 @@ clr_autoboot_at_boot:
   bra -
 + lda #$55
   sta @MCU_CMD
-; pretend START button had already been pressed so subsequent read_pads don't
-; detect a START press
-  lda #$10
-  sta pad1mem+1
   plp
   rts
 

--- a/snes/main.a65
+++ b/snes/main.a65
@@ -86,19 +86,13 @@ coldboot:       ; Regular, cold-start init
   jsr detect_ultra16
   jsr detect_satellaview
   jsr wait_mcu_ready
-  ; Check if an autoboot ROM is configured.
-  ; Screen is still in force-blank ($2100=$8f from snes_init) — no menu is
-  ; visible yet.  If autoboot fires successfully the MCU hardware-resets the
-  ; SNES and we never return, so the user sees no menu flash at all.
-  ; Only if no autoboot is set, START is held, or the ROM can't be loaded do
-  ; we fall through to the normal screen_on / filesel_init path below.
-  sep #$20 : .as
+  ; Check autoboot flag (set by MCU if autoboot.cfg is present)
+  ; Screen is still black (tgt_bright set in video_init)
+  ; If autoboot is inactive, START is held, or the ROM can't be loaded:
+  ; fall through to normal menu startup
   lda @ST_AUTOBOOT_ENABLED
   beq coldboot_autoboot_out       ; no autoboot configured
-  ; setup_hdma already set $4200=$81 (NMI + joypad auto-read enabled).
-  ; Do NOT touch $4200 — disabling NMI would freeze fileselloop.
-  ; Poll START for ~60 frames (~1 second) so the user has time to react.
-  rep #$10 : .xl        ; 16-bit index for loop counter
+  ; Poll the controller for ~60 frames (~1 second) so the user has time to act.
   ldx #60
 autoboot_start_poll:
   jsr waitblank         ; sync to VBlank boundary (NMI fires here, sets isr_done)
@@ -109,11 +103,10 @@ autoboot_start_poll:
   bne coldboot_bypass_autoboot    ; START pressed -> bypass autoboot
   dex
   bne autoboot_start_poll
-  ; START not held after ~1 second: trigger autoboot
+  ; timeout - START not pressed after ~1 second: trigger autoboot
   jsr autoboot_cmd_handshake
   bra coldboot_autoboot_out
-coldboot_bypass_autoboot:
-  ; START was held: clear autoboot for future boots and show menu
+coldboot_bypass_autoboot:         ; clear autoboot flag, continue to menu
   jsr clr_autoboot_at_boot
 coldboot_autoboot_out:
   jsr screen_on
@@ -678,9 +671,7 @@ wait_mcu_ready:
   rts
 
 ; autoboot_cmd_handshake: send CMD_LOAD_AUTOBOOT to MCU and wait for response.
-; If MCU loads a ROM it will hardware-reset the SNES — we never return in that case.
-; If MCU NACKs (0xaa) or sends ready (0x55, e.g. old firmware), pop the loading
-; window and return so fileselloop can continue normally.
+; return to menu if autoboot ROM loading fails (e.g. file not found)
 ; NOTE: do NOT call WRAM_ROUTINE here — MCU uses LOADROM_WITH_RESET only.
 autoboot_cmd_handshake:
   php

--- a/snes/main.a65
+++ b/snes/main.a65
@@ -90,6 +90,32 @@ coldboot:       ; Regular, cold-start init
   beq +
   jsl rtc_init
 +
+  ; Check if an autoboot ROM is configured
+  sep #$20 : .as
+  lda @ST_AUTOBOOT_ENABLED
+  beq coldboot_autoboot_out       ; no autoboot configured
+  ; setup_hdma already set $4200=$81 (NMI + joypad auto-read enabled).
+  ; Do NOT touch $4200 — disabling NMI would freeze fileselloop.
+  ; Poll START for ~60 frames (~1 second) so the user has time to react.
+  rep #$10 : .xl        ; 16-bit index for loop counter
+  ldx #60
+autoboot_start_poll:
+  jsr waitblank         ; sync to VBlank boundary (NMI fires here, sets isr_done)
+- lda @$004212          ; HVBJOY: bit 0 = auto-joypad read in progress
+  and #$01
+  bne -                 ; wait until auto-read is done
+  lda @$004219          ; joypad 1 high byte: B,Y,SEL,STA,UP,DN,L,R
+  and #$10              ; bit 4 = START
+  bne coldboot_bypass_autoboot    ; START held -> bypass autoboot
+  dex
+  bne autoboot_start_poll
+  ; START not held after ~1 second: trigger autoboot
+  jsr autoboot_cmd_handshake
+  bra coldboot_autoboot_out
+coldboot_bypass_autoboot:
+  ; START was held: clear autoboot for future boots and show menu
+  jsr clr_autoboot_at_boot
+coldboot_autoboot_out:
   jsr fileselloop
   sei
   stz $4200
@@ -640,6 +666,64 @@ wait_mcu_ready:
 - lda @SNES_CMD
   cmp #$55
   bne -
+  plp
+  rts
+
+; autoboot_cmd_handshake: send CMD_LOAD_AUTOBOOT to MCU and wait for response.
+; If MCU loads a ROM it will hardware-reset the SNES — we never return in that case.
+; If MCU NACKs (0xaa) or sends ready (0x55, e.g. old firmware), pop the loading
+; window and return so fileselloop can continue normally.
+; NOTE: do NOT call WRAM_ROUTINE here — MCU uses LOADROM_WITH_RESET only.
+autoboot_cmd_handshake:
+  php
+  phb
+  sep #$20 : .as
+  lda #$01
+  jsr hide_cursor
+  jsr draw_loading_window
+  jsr waitblank
+  lda #$00
+  sta @SNES_CMD
+  lda #CMD_LOAD_AUTOBOOT
+  sta @MCU_CMD
+- lda @SNES_CMD
+  cmp #$55
+  beq +
+  cmp #$aa
+  beq +
+  bra -
++ lda #$55
+  sta @MCU_CMD
+  jsr pop_window
+  plb
+  plp
+  rts
+
+; clr_autoboot_at_boot: called at cold boot when START is held.
+; Sends CMD_CLR_AUTOBOOT_ROM to clear the autoboot ROM setting.
+; Does NOT load a ROM; returns so the normal menu loop can proceed.
+clr_autoboot_at_boot:
+  php
+  phb
+  sep #$20 : .as
+  lda #$01
+  jsr hide_cursor
+  jsr draw_loading_window
+  jsr waitblank
+  lda #$00
+  sta @SNES_CMD
+  lda #CMD_CLR_AUTOBOOT_ROM
+  sta @MCU_CMD
+- lda @SNES_CMD
+  cmp #$55
+  beq +
+  cmp #$aa
+  beq +
+  bra -
++ lda #$55
+  sta @MCU_CMD
+  jsr pop_window
+  plb
   plp
   rts
 

--- a/snes/main.a65
+++ b/snes/main.a65
@@ -51,12 +51,14 @@ GAME_MAIN:
   jsr store_wram_routines
   jsr colortest
   jsr video_init
+  jsr pad_init
   jsr setup_hdma
   jsr detect_ultra16
   jsr detect_satellaview
   lda @CFG_BRIGHTNESS_LIMIT
   sta cur_bright
   sta tgt_bright
+  sta menu_brightness
   sta $2100
   jmp @set_bank ; Set bios bank, just to be sure
 set_bank:
@@ -79,6 +81,7 @@ coldboot:       ; Regular, cold-start init
   jsr store_wram_routines
   jsr colortest
   jsr video_init
+  jsr pad_init
   jsr setup_hdma
   jsr detect_ultra16
   jsr detect_satellaview
@@ -334,6 +337,7 @@ video_init:
   sta bar_yl
   stz cur_bright
   stz tgt_bright
+  stz menu_brightness
   lda #$01
   sta fade_speed
   stz fade_count

--- a/snes/memmap.i65
+++ b/snes/memmap.i65
@@ -179,3 +179,5 @@
 #define TYPE_SKIN                   $06
 #define TYPE_SUBDIR                 $40
 #define TYPE_PARENT                 $80
+
+#define DIM_BRIGHTNESS              $03

--- a/snes/memmap.i65
+++ b/snes/memmap.i65
@@ -80,6 +80,10 @@
 #define CMD_LED_BRIGHTNESS          $12
 #define CMD_ADD_FAVORITE_ROM        $13
 #define CMD_REMOVE_FAVORITE_ROM     $14
+#define CMD_SET_AUTOBOOT_ROM        $15 /* set autoboot from file browser */
+#define CMD_SET_AUTOBOOT_FAV        $16 /* set autoboot from favorites (index in MCU_PARAM) */
+#define CMD_CLR_AUTOBOOT_ROM        $17 /* clear autoboot ROM setting */
+#define CMD_LOAD_AUTOBOOT           $18 /* trigger autoboot at cold boot */
 #define CMD_SAVESTATE               $40
 #define CMD_LOADSTATE               $41
 #define CMD_MCU_RDY                 $55
@@ -141,6 +145,7 @@
 #define ST_NUM_RECENT_GAMES         ST_MCU_ADDR+$0001
 #define ST_PAIRMODE                 ST_MCU_ADDR+$0002
 #define ST_NUM_FAVORITE_GAMES       ST_MCU_ADDR+$0003
+#define ST_AUTOBOOT_ENABLED         ST_MCU_ADDR+$0004
 
 #define ST_IS_U16                   ST_SNES_ADDR+$0000
 #define ST_U16_CFG                  ST_SNES_ADDR+$0001

--- a/snes/menudata.a65
+++ b/snes/menudata.a65
@@ -896,7 +896,7 @@ mfunc_isenabled_autosave:
 
 mfunc_chg_brightness:
   sta @tgt_bright
-  sta @bright_limit
+  sta @menu_brightness
   rtl
 
 mfunc_chg_ledbright:

--- a/snes/menudata.a65
+++ b/snes/menudata.a65
@@ -792,6 +792,19 @@ menu_enttab_filesel_context_file:
  .byt  0,0,0
  .byt  0,0,0
 
+ .byt  MTYPE_FUNC_CLOSE
+ .word !text_filesel_context_set_as_autoboot
+ .byt  ^text_filesel_context_set_as_autoboot
+ .word !set_selected_as_autoboot_rom-1
+ .byt  ^set_selected_as_autoboot_rom-1
+ .byt  0
+ .byt  0,0,0
+ .word !mdesc_filesel_context_set_as_autoboot
+ .byt  ^mdesc_filesel_context_set_as_autoboot
+ .byt  0,0,0
+ .byt  0,0,0
+ .byt  0,0,0
+
  .byt  0
 
 menu_enttab_filesel_favorites_context:
@@ -809,6 +822,19 @@ menu_enttab_filesel_favorites_context:
  .byt  0,0,0
  .word !mdesc_filesel_favorites_context_remove_from_favorites
  .byt  ^mdesc_filesel_favorites_context_remove_from_favorites
+ .byt  0,0,0
+ .byt  0,0,0
+ .byt  0,0,0
+
+ .byt  MTYPE_FUNC_CLOSE
+ .word !text_filesel_favorites_context_set_as_autoboot
+ .byt  ^text_filesel_favorites_context_set_as_autoboot
+ .word !set_favorite_as_autoboot_rom-1
+ .byt  ^set_favorite_as_autoboot_rom-1
+ .byt  0
+ .byt  0,0,0
+ .word !mdesc_filesel_favorites_context_set_as_autoboot
+ .byt  ^mdesc_filesel_favorites_context_set_as_autoboot
  .byt  0,0,0
  .byt  0,0,0
  .byt  0,0,0

--- a/snes/pad.a65
+++ b/snes/pad.a65
@@ -1,4 +1,13 @@
 .link page $c0
+
+pad_init:
+  php
+  rep #$30 : .xl : .al
+  stz pad1mem
+  stz pad1trig
+  plp
+  rts
+
 read_pad:
   php
   phb
@@ -14,24 +23,24 @@ read_pad:
     stz pad_a      ; (including x)
     stz pad_l      ; (including r)
 
-read_pad1
-    ldx pad1mem   ;byetUDLRaxlriiii
-    lda $4218
-    and #$000f
+read_pad1         ; byetUDLRaxlriiii
+    ldx pad1mem   ; save previous state of the buttons for later
+    lda $4218     ; Controller 1
+    and #$000f    ; ignore non-standard controllers (ID != 0)
     bne +
     lda $4218
 +   sta pad1mem
-    lda $421a
-    and #$000f
+    lda $421a     ; Controller 2
+    and #$000f    ; ignore non-standard controllers (ID != 0)
     bne +
     lda $421a
-+   ora pad1mem
++   ora pad1mem   ; combine buttons of both controllers
     sta pad1mem
-    and #$0f00
+    and #$0f00    ; UDLR = directional buttons support auto-repeat
     bne read_pad1_count
     stz pad1delay
 read_pad1_cont1
-    txa
+    txa           ; restore previous state of the buttons in A for comparison (for button press event detection)
     eor pad1mem
     and pad1mem
     sta pad1trig

--- a/snes/reset.a65
+++ b/snes/reset.a65
@@ -70,7 +70,7 @@ math_cont
   beq nobuttonspressed
 buttonspressed
   stz idle_count
-  lda bright_limit
+  lda menu_brightness ; restore normal brightness when button pressed
   tax
   stx tgt_bright
   ldx #$01
@@ -83,7 +83,7 @@ nobuttonspressed
   sep #$20 : .as
   bne +
 ; no input for a long time
-  ldx #$03
+  ldx #DIM_BRIGHTNESS
   stx tgt_bright
   ldx #$10
   stx fade_speed

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -525,6 +525,61 @@ void cfg_dump_favorite_games_for_snes(uint32_t address) {
   file_close();
 }
 
+/* ---- Autoboot ROM functions ---- */
+
+uint8_t cfg_is_autoboot_enabled() {
+  uint8_t fn[4];
+  fn[0] = 0;
+  file_open(AUTOBOOT_FILE, FA_READ);
+  if(file_status != FILE_OK) {
+    if(file_res == FR_NO_FILE || file_res == FR_NO_PATH) {
+      file_res = FR_OK;
+    }
+    return 0;
+  }
+  f_gets((TCHAR*)fn, sizeof(fn), &file_handle);
+  file_close();
+  return fn[0] != 0;
+}
+
+int cfg_get_autoboot_rom(uint8_t *fn) {
+  fn[0] = 0;
+  file_open(AUTOBOOT_FILE, FA_READ);
+  if(file_status != FILE_OK) {
+    if(file_res == FR_NO_FILE || file_res == FR_NO_PATH) {
+      file_res = FR_OK;
+    }
+    return 1;
+  }
+  f_gets((TCHAR*)fn, 255, &file_handle);
+  file_close();
+  return (fn[0] == 0) ? 1 : 0;
+}
+
+int cfg_set_autoboot_rom(const uint8_t *fn) {
+  int err = 0;
+  TCHAR fqfn[256];
+  fqfn[0] = 0;
+  if(fn[0] != '/') {
+    strncpy(fqfn, (const char*)file_path, 256);
+    fqfn[255] = 0;
+  }
+  strncat(fqfn, (const char*)fn, 256 - strlen(fqfn) - 1);
+  file_open(AUTOBOOT_FILE, FA_CREATE_ALWAYS | FA_WRITE);
+  err = f_puts((const TCHAR*)fqfn, &file_handle);
+  err |= (f_putc(0, &file_handle) == EOF) ? 1 : 0;
+  file_close();
+  return err;
+}
+
+int cfg_clr_autoboot_rom() {
+  f_unlink((TCHAR*)AUTOBOOT_FILE);
+  if(file_res == FR_NO_FILE || file_res == FR_NO_PATH) {
+    file_res = FR_OK;
+  }
+  return 0;
+}
+
 /* make binary config available to menu */
 void cfg_load_to_menu() {
   sram_writeblock(&CFG, SRAM_MENU_CFG_ADDR, sizeof(cfg_t));

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -6,8 +6,10 @@
 #define CFG_FILE ("/sd2snes/config.yml")
 #define LAST_FILE ((const uint8_t*)"/sd2snes/lastgame.cfg")
 #define LAST_FILE_BAK ((const uint8_t*)"/sd2snes/~lastgame.cfg")
-#define FAVORITES_FILE ((const uint8_t*)"/sd2snes/favorites.cfg")
+#define FAVORITES_FILE     ((const uint8_t*)"/sd2snes/favorites.cfg")
 #define FAVORITES_FILE_BAK ((const uint8_t*)"/sd2snes/~favorites.cfg")
+#define AUTOBOOT_FILE      ((const uint8_t*)"/sd2snes/autoboot.cfg")
+#define AUTOBOOT_FILE_BAK  ((const uint8_t*)"/sd2snes/~autoboot.cfg")
 
 #define CFG_VIDMODE_MENU                 ("VideoModeMenu")
 #define CFG_VIDMODE_GAME                 ("VideoModeGame")
@@ -113,6 +115,11 @@ int cfg_add_favorite_game(uint8_t *fn);
 int cfg_remove_favorite_game(uint8_t index_to_remove);
 int cfg_get_favorite_game(uint8_t *fn, uint8_t index);
 void cfg_dump_favorite_games_for_snes(uint32_t address);
+
+uint8_t cfg_is_autoboot_enabled(void);
+int cfg_get_autoboot_rom(uint8_t *fn);
+int cfg_set_autoboot_rom(const uint8_t *fn);
+int cfg_clr_autoboot_rom(void);
 
 void cfg_load_to_menu(void);
 void cfg_get_from_menu(void);

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -9,7 +9,6 @@
 #define FAVORITES_FILE     ((const uint8_t*)"/sd2snes/favorites.cfg")
 #define FAVORITES_FILE_BAK ((const uint8_t*)"/sd2snes/~favorites.cfg")
 #define AUTOBOOT_FILE      ((const uint8_t*)"/sd2snes/autoboot.cfg")
-#define AUTOBOOT_FILE_BAK  ((const uint8_t*)"/sd2snes/~autoboot.cfg")
 
 #define CFG_VIDMODE_MENU                 ("VideoModeMenu")
 #define CFG_VIDMODE_GAME                 ("VideoModeGame")

--- a/src/main.c
+++ b/src/main.c
@@ -268,9 +268,6 @@ int main(void) {
         STM.pairmode = 0;
     }
     STM.autoboot_enabled = cfg_is_autoboot_enabled();
-    /* Clear any transient file_res left by init-phase file probing (e.g.
-       validity checks, autoboot.cfg probe) so led_error() stays silent. */
-    file_res = FR_OK;
     status_load_to_menu();
 
     uint8_t cmd = 0;
@@ -419,16 +416,11 @@ int main(void) {
           printf("Autobooting: %s\n", file_lfn);
           if(file_lfn[0]) {
             cfg_add_last_game(file_lfn);
-            /* LOADROM_WITH_RESET (no WAIT_SNES): MCU directly hardware-resets SNES.
-               SNES side uses autoboot_cmd_handshake which does NOT call WRAM_ROUTINE,
-               so the WAIT_SNES handshake is not needed and must not be used. */
-            filesize = load_rom(file_lfn, SRAM_ROM_ADDR, LOADROM_WITH_SRAM | LOADROM_WITH_RESET);
+            filesize = load_rom(file_lfn, SRAM_ROM_ADDR, LOADROM_WITH_SRAM | LOADROM_WITH_RESET | LOADROM_WAIT_SNES);
             if(filesize) break; /* ROM loaded and SNES reset, exit menu loop */
           }
-          /* No ROM loaded (empty path, file not found, or load error):
-             Clear file_res unconditionally so led_error() does not blink.
-             file_res may be FR_NO_FILE, FR_INVALID_OBJECT, or other transient
-             values left by cfg_add_last_game / load_rom file operations. */
+          /* clear file error state from any potential cause of failure
+             (prevent LED blinking) */
           file_res = FR_OK;
           /* NACK so autoboot_cmd_handshake returns cleanly to menu */
           snescmd_writebyte(0xaa, SNESCMD_SNES_CMD);

--- a/src/main.c
+++ b/src/main.c
@@ -267,6 +267,10 @@ int main(void) {
       default:
         STM.pairmode = 0;
     }
+    STM.autoboot_enabled = cfg_is_autoboot_enabled();
+    /* Clear any transient file_res left by init-phase file probing (e.g.
+       validity checks, autoboot.cfg probe) so led_error() stays silent. */
+    file_res = FR_OK;
     status_load_to_menu();
 
     uint8_t cmd = 0;
@@ -386,6 +390,49 @@ int main(void) {
           cfg_dump_favorite_games_for_snes(SRAM_FAVORITEGAMES_ADDR);
           status_load_to_menu();
           cmd=0; /* stay in menu loop */
+          break;
+        case SNES_CMD_SET_AUTOBOOT_ROM:
+          get_selected_name(file_lfn);
+          printf("Set autoboot ROM: %s\n", file_lfn);
+          cfg_set_autoboot_rom(file_lfn);
+          STM.autoboot_enabled = 1;
+          status_load_to_menu();
+          cmd=0; /* stay in menu loop */
+          break;
+        case SNES_CMD_SET_AUTOBOOT_FAV:
+          cfg_get_favorite_game(file_lfn, snes_get_mcu_param() & 0xff);
+          printf("Set autoboot from favorite: %s\n", file_lfn);
+          cfg_set_autoboot_rom(file_lfn);
+          STM.autoboot_enabled = 1;
+          status_load_to_menu();
+          cmd=0; /* stay in menu loop */
+          break;
+        case SNES_CMD_CLR_AUTOBOOT_ROM:
+          printf("Clear autoboot ROM\n");
+          cfg_clr_autoboot_rom();
+          STM.autoboot_enabled = 0;
+          status_load_to_menu();
+          cmd=0; /* stay in menu loop */
+          break;
+        case SNES_CMD_LOAD_AUTOBOOT:
+          cfg_get_autoboot_rom(file_lfn);
+          printf("Autobooting: %s\n", file_lfn);
+          if(file_lfn[0]) {
+            cfg_add_last_game(file_lfn);
+            /* LOADROM_WITH_RESET (no WAIT_SNES): MCU directly hardware-resets SNES.
+               SNES side uses autoboot_cmd_handshake which does NOT call WRAM_ROUTINE,
+               so the WAIT_SNES handshake is not needed and must not be used. */
+            filesize = load_rom(file_lfn, SRAM_ROM_ADDR, LOADROM_WITH_SRAM | LOADROM_WITH_RESET);
+            if(filesize) break; /* ROM loaded and SNES reset, exit menu loop */
+          }
+          /* No ROM loaded (empty path, file not found, or load error):
+             Clear file_res unconditionally so led_error() does not blink.
+             file_res may be FR_NO_FILE, FR_INVALID_OBJECT, or other transient
+             values left by cfg_add_last_game / load_rom file operations. */
+          file_res = FR_OK;
+          /* NACK so autoboot_cmd_handshake returns cleanly to menu */
+          snescmd_writebyte(0xaa, SNESCMD_SNES_CMD);
+          cmd=0;
           break;
         case SNES_CMD_LOAD_CHT:
           /* load cheats */

--- a/src/snes.h
+++ b/src/snes.h
@@ -44,6 +44,10 @@
 #define SNES_CMD_LED_BRIGHTNESS      (0x12)
 #define SNES_CMD_ADD_FAVORITE_ROM    (0x13)
 #define SNES_CMD_REMOVE_FAVORITE_ROM (0x14)
+#define SNES_CMD_SET_AUTOBOOT_ROM    (0x15) /* set autoboot from file browser selection */
+#define SNES_CMD_SET_AUTOBOOT_FAV    (0x16) /* set autoboot from favorites list (index in MCU_PARAM) */
+#define SNES_CMD_CLR_AUTOBOOT_ROM    (0x17) /* clear autoboot ROM setting */
+#define SNES_CMD_LOAD_AUTOBOOT       (0x18) /* boot into the stored autoboot ROM */
 
 #define SNES_CMD_SAVESTATE           (0x40)
 #define SNES_CMD_LOADSTATE           (0x41)
@@ -143,6 +147,7 @@ typedef struct __attribute__ ((__packed__)) _mcu_status {
   uint8_t num_recent_games;
   uint8_t pairmode;
   uint8_t num_favorite_games;
+  uint8_t autoboot_enabled;    /* 1 if an autoboot ROM is configured */
 } mcu_status_t;
 
 typedef struct __attribute__ ((__packed__)) _snes_status {


### PR DESCRIPTION
May close #85 

Adds the ability to configure a ROM that boots automatically on power-on.


How to use?

- Navigate to a ROM of your choice, press Y and choose "Set as autoboot". Its the existing menu where you can add favorites.
- You can disable by holding START on coldboot or reset.

Technical caveats:
- It adds an autoboot.cfg with the path of the rom. It will be deleted when holding START.
- Boot order is mcufw -> menu -> rom.
- mcufw -> boot rom would be possible, however we need the menu to detect START being held. We can use holding RESET but this may interfere with other hardware mods.

Possible improvements:
- Add directboot=1 to autboot.cfg which skips the menu completely, however exiting autoboot mode would require manual editing.

Precompiled demo based on 1.11.1 commit a745440:
https://www.techspark.de/wp-content/uploads/2026/03/sd2snes-v1.11.1-SNAPSHOT-autoboot.zip
