### PR TITLE
Enable SuperFX (GSU) FPGA core for HiROM ROMs

### DIFF
--- a/src/smc.c
+++ b/src/smc.c
@@ -218,6 +218,14 @@ void smc_id(snes_romprops_t* props, uint32_t file_offset) {
         props->fpga_conf = FPGA_DSP;
         props->fpga_features |= FEAT_DSPX;
       }
+      /* SuperFX HiROM (homebrew - no commercial cart used this combination) */
+      else if ((header->carttype >= 0x13 && header->carttype <= 0x15) ||
+          header->carttype == 0x1a) {
+        props->has_gsu = 1;
+        props->fpga_conf = FPGA_GSU;
+        props->fpga_dspfeat = CFG.gsu_speed;
+        header->ramsize = header->expramsize & 0x7;
+      }
       else if (header->carttype == 0xcb) {
         // custom combo type
         props->has_combo = 1;


### PR DESCRIPTION
## Summary

- Adds GSU cart type detection (`0x13`-`0x15`, `0x1a`) to the HiROM (`0x21`) case in `smc_id()`
- Mirrors the existing LoROM GSU detection — same `has_gsu`, `fpga_conf`, `fpga_dspfeat`, and `ramsize` setup
- Enables the GSU FPGA core for homebrew HiROM+SuperFX ROMs on FXPak Pro

## Context

No commercial SNES cartridge ever combined HiROM with SuperFX — all retail SuperFX games (Star Fox, Doom, Yoshi's Island, etc.) used LoROM. However, homebrew projects can benefit from HiROM's 64KB contiguous banks alongside the GSU-2 coprocessor.

Currently, the FXPak firmware only enables the GSU FPGA core for LoROM ROMs (`header->map == 0x20`). HiROM ROMs with GSU cart types (`$15` = ROM+GSU+RAM+Battery) are not recognized, leaving the GSU registers unmapped (VCR reads `$00`).

## Testing

artifact:  [4MB HiROM+GSU+MSU-1 test ROM](https://github.com/astrobleem/SNES-HiRomGsuTest):



The GSU FPGA core itself works correctly with HiROM — the SuperFX accesses ROM via its own ROMBR register and RAM via `$70`-`$71`, independent of the SNES address mapping mode.

## Change

One `else if` block (7 lines) added to the `case 0x21` (HiROM) handler in `src/smc.c`, identical to the existing LoROM GSU detection in `case 0x20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)