### PR TITLE
feat: Added Sufami Turbo Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.log
 *.smc
 *.sfc
+*.st
 *~
 *.old
 *.elf

--- a/snes/const.a65
+++ b/snes/const.a65
@@ -293,6 +293,8 @@ mdesc_filesel_context_add_to_favorites .byt "Add the selected file to favorites"
 
 text_filesel_context_set_as_autoboot .byt "Set as autoboot", 0
 mdesc_filesel_context_set_as_autoboot .byt "Boot this ROM automatically on next power-on (hold START to cancel)", 0
+text_filesel_context_set_as_slotb .byt "Set as Slot B", 0
+mdesc_filesel_context_set_as_slotb .byt "Load this .ST ROM as the Sufami Turbo Slot B companion cart", 0
 
 text_filesel_favorites_context_remove_from_favorites .byt "Remove from favorites", 0
 mdesc_filesel_favorites_context_remove_from_favorites .byt "Remove the selected file from favorites", 0

--- a/snes/filesel.a65
+++ b/snes/filesel.a65
@@ -565,6 +565,8 @@ select_item:
   lda [dirptr_addr], y
   cmp #TYPE_ROM
   beq sel_is_file
+  cmp #TYPE_ROM_ST
+  beq sel_is_file
   cmp #TYPE_SPC
   beq sel_is_spc
   cmp #TYPE_SUBDIR
@@ -800,6 +802,8 @@ open_context_menu:
   lda [dirptr_addr], y
   cmp #TYPE_ROM
   beq ctx_is_file
+  cmp #TYPE_ROM_ST
+  beq ctx_is_file_st
   cmp #TYPE_SPC
   beq ctx_is_spc
   cmp #TYPE_SUBDIR
@@ -827,6 +831,26 @@ ctx_is_file
   lda #$00
   sta @MCU_PARAM+3
   jsr filesel_contextmenu_file
+  bra open_context_menu_cont
+ctx_is_file_st
+; save selected ST file path to MCU_PARAM (same as ctx_is_file)
+  dey
+  rep #$20 : .al
+  lda [dirptr_addr], y
+  and #$00ff
+  sta @MCU_PARAM+6
+  dey
+  dey
+  lda [dirptr_addr], y
+  sta @MCU_PARAM+4
+  lda #!FILESEL_CWD
+  sta @MCU_PARAM
+  sep #$20 : .as
+  lda #^FILESEL_CWD
+  sta @MCU_PARAM+2
+  lda #$00
+  sta @MCU_PARAM+3
+  jsr filesel_contextmenu_st_file
   bra open_context_menu_cont
 ctx_is_parent
   bra open_context_menu_cont
@@ -1157,6 +1181,37 @@ set_selected_as_autoboot_rom:
   plp
   rtl
 
+set_selected_as_slotb_rom:
+; have MCU store the selected .ST file as the Slot B companion cart
+; the file path should already have been saved to MCU_PARAM before calling
+; this routine (done by open_context_menu / ctx_is_file_st)
+  php
+  phb
+  sep #$20 : .as
+  lda #$01
+  jsr hide_cursor
+  jsr draw_loading_window
+  jsr waitblank
+  lda #$00
+  sta @SNES_CMD
+  lda #CMD_SET_SLOTB_ROM
+  sta @MCU_CMD
+; wait for ACK/NACK
+- lda @SNES_CMD
+  cmp #$55
+; success
+  beq +
+  cmp #$aa
+; failure
+  beq +
+  bra -
++ lda #$55
+  sta @MCU_CMD
+  jsr pop_window
+  plb
+  plp
+  rtl
+
 set_favorite_as_autoboot_rom:
 ; have MCU save the selected favorite game as the autoboot ROM
 ; the list index of the favorite should already have been saved to MCU_PARAM
@@ -1287,8 +1342,10 @@ filesel_request_filelist:
   sta @MCU_PARAM+10
   lda #TYPE_SPC
   sta @MCU_PARAM+11
-  lda #$00
+  lda #TYPE_ROM_ST
   sta @MCU_PARAM+12
+  lda #$00
+  sta @MCU_PARAM+13
   sta @SNES_CMD
   lda #CMD_READDIR
   sta @MCU_CMD

--- a/snes/memmap.i65
+++ b/snes/memmap.i65
@@ -84,6 +84,8 @@
 #define CMD_SET_AUTOBOOT_FAV        $16 /* set autoboot from favorites (index in MCU_PARAM) */
 #define CMD_CLR_AUTOBOOT_ROM        $17 /* clear autoboot ROM setting */
 #define CMD_LOAD_AUTOBOOT           $18 /* trigger autoboot at cold boot */
+#define CMD_SET_SLOTB_ROM           $19 /* set Slot B companion cart for Sufami Turbo (non-persistent) */
+#define CMD_SET_SLOTB_ROM           $19 /* set Slot B companion cart for Sufami Turbo (non-persistent) */
 #define CMD_SAVESTATE               $40
 #define CMD_LOADSTATE               $41
 #define CMD_MCU_RDY                 $55
@@ -174,6 +176,7 @@
 #define TYPE_ROM                    $01
 #define TYPE_SRM                    $02
 #define TYPE_SPC                    $03
+#define TYPE_ROM_ST                 $07
 #define TYPE_IPS                    $04
 #define TYPE_CHT                    $05
 #define TYPE_SKIN                   $06

--- a/snes/memmap.i65
+++ b/snes/memmap.i65
@@ -85,7 +85,6 @@
 #define CMD_CLR_AUTOBOOT_ROM        $17 /* clear autoboot ROM setting */
 #define CMD_LOAD_AUTOBOOT           $18 /* trigger autoboot at cold boot */
 #define CMD_SET_SLOTB_ROM           $19 /* set Slot B companion cart for Sufami Turbo (non-persistent) */
-#define CMD_SET_SLOTB_ROM           $19 /* set Slot B companion cart for Sufami Turbo (non-persistent) */
 #define CMD_SAVESTATE               $40
 #define CMD_LOADSTATE               $41
 #define CMD_MCU_RDY                 $55

--- a/snes/menu.a65
+++ b/snes/menu.a65
@@ -60,6 +60,33 @@ filesel_contextmenu_file:
   jsr pop_window
   rts
 
+filesel_contextmenu_st_file:
+  sep #$20 : .as
+  rep #$10 : .xl
+  lda #$02
+  sta window_x
+  lda #$09
+  sta window_y
+  lda #60
+  sta window_w
+  lda #18
+  sta window_h
+  jsr push_window
+  jsr window_greyout
+  lda #$06
+  sta window_x
+  lda #$0b
+  sta window_y
+  phb
+    lda #^menu_enttab_filesel_context_st_file
+    pha
+    plb
+    ldx #!menu_enttab_filesel_context_st_file
+    jsr show_menu
+  plb
+  jsr pop_window
+  rts
+
 filesel_favorites_contextmenu:
   sep #$20 : .as
   rep #$10 : .xl

--- a/snes/menudata.a65
+++ b/snes/menudata.a65
@@ -807,6 +807,53 @@ menu_enttab_filesel_context_file:
 
  .byt  0
 
+menu_enttab_filesel_context_st_file:
+; HEADER
+ .byt  1              ; listsel_step=1
+ .word !text_filesel_selected_file ; window title
+ .byt  ^text_filesel_selected_file ; for this menu
+; ENTRIES
+ .byt  MTYPE_FUNC_CLOSE
+ .word !text_filesel_context_add_to_favorites
+ .byt  ^text_filesel_context_add_to_favorites
+ .word !add_selected_file_to_favorites-1
+ .byt  ^add_selected_file_to_favorites-1
+ .byt  0
+ .byt  0,0,0
+ .word !mdesc_filesel_context_add_to_favorites
+ .byt  ^mdesc_filesel_context_add_to_favorites
+ .byt  0,0,0
+ .byt  0,0,0
+ .byt  0,0,0
+
+ .byt  MTYPE_FUNC_CLOSE
+ .word !text_filesel_context_set_as_autoboot
+ .byt  ^text_filesel_context_set_as_autoboot
+ .word !set_selected_as_autoboot_rom-1
+ .byt  ^set_selected_as_autoboot_rom-1
+ .byt  0
+ .byt  0,0,0
+ .word !mdesc_filesel_context_set_as_autoboot
+ .byt  ^mdesc_filesel_context_set_as_autoboot
+ .byt  0,0,0
+ .byt  0,0,0
+ .byt  0,0,0
+
+ .byt  MTYPE_FUNC_CLOSE
+ .word !text_filesel_context_set_as_slotb
+ .byt  ^text_filesel_context_set_as_slotb
+ .word !set_selected_as_slotb_rom-1
+ .byt  ^set_selected_as_slotb_rom-1
+ .byt  0
+ .byt  0,0,0
+ .word !mdesc_filesel_context_set_as_slotb
+ .byt  ^mdesc_filesel_context_set_as_slotb
+ .byt  0,0,0
+ .byt  0,0,0
+ .byt  0,0,0
+
+ .byt  0
+
 menu_enttab_filesel_favorites_context:
 ; HEADER
  .byt  1              ; listsel_step=1

--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -151,6 +151,7 @@ SNES_FTYPE determine_filetype(FILINFO fno) {
      ||(!strcasecmp(ext+1, "GB"))
      ||(!strcasecmp(ext+1, "GBC"))
      ||(!strcasecmp(ext+1, "SGB"))
+     ||(!strcasecmp(ext+1, "ST"))
     ) {
     return TYPE_ROM;
   }

--- a/src/filetypes.c
+++ b/src/filetypes.c
@@ -80,6 +80,7 @@ printf("start\n");
       if(is_requested_filetype(type, filetypes)) {
         switch(type) {
           case TYPE_ROM:
+          case TYPE_ROM_ST:
           case TYPE_SPC:
           case TYPE_SUBDIR:
           case TYPE_PARENT:
@@ -151,9 +152,11 @@ SNES_FTYPE determine_filetype(FILINFO fno) {
      ||(!strcasecmp(ext+1, "GB"))
      ||(!strcasecmp(ext+1, "GBC"))
      ||(!strcasecmp(ext+1, "SGB"))
-     ||(!strcasecmp(ext+1, "ST"))
     ) {
     return TYPE_ROM;
+  }
+  if(!strcasecmp(ext+1, "ST")) {
+    return TYPE_ROM_ST;
   }
 /*  if(  (!strcasecmp(ext+1, "IPS"))
      ||(!strcasecmp(ext+1, "UPS"))

--- a/src/filetypes.h
+++ b/src/filetypes.h
@@ -46,6 +46,7 @@ typedef enum {
   TYPE_IPS     =   4,
   TYPE_CHT     =   5,
   TYPE_SKIN    =   6,
+  TYPE_ROM_ST  =   7,
   TYPE_SUBDIR  =  64,
   TYPE_PARENT  = 128
 } SNES_FTYPE;

--- a/src/fpga_spi.c
+++ b/src/fpga_spi.c
@@ -222,6 +222,15 @@ void set_rom_mask(uint32_t mask) {
   FPGA_DESELECT();
 }
 
+void set_rom_mask_b(uint32_t mask) {
+  FPGA_SELECT();
+  FPGA_TX_BYTE(FPGA_CMD_SETROMMASK_B);
+  FPGA_TX_BYTE((mask >> 16) & 0xff);
+  FPGA_TX_BYTE((mask >> 8) & 0xff);
+  FPGA_TX_BYTE((mask) & 0xff);
+  FPGA_DESELECT();
+}
+
 void set_mapper(uint8_t val) {
   FPGA_SELECT();
   FPGA_TX_BYTE(FPGA_CMD_SETMAPPER(val));

--- a/src/fpga_spi.h
+++ b/src/fpga_spi.h
@@ -68,6 +68,7 @@
 /* commands */
 #define FPGA_CMD_SETADDR         (0x00)
 #define FPGA_CMD_SETROMMASK      (0x10)
+#define FPGA_CMD_SETROMMASK_B    (0x50)
 #define FPGA_CMD_SETRAMMASK      (0x20)
 #define FPGA_CMD_SETRAMBASE      (0x20 | 1)
 #define FPGA_CMD_SETMAPPER(x)    (0x30 | (x & 15))
@@ -124,6 +125,7 @@ void set_msu_status(uint16_t status);
 void set_saveram_base(uint8_t);
 void set_saveram_mask(uint32_t);
 void set_rom_mask(uint32_t);
+void set_rom_mask_b(uint32_t);
 void set_mapper(uint8_t val);
 void fpga_sddma(uint8_t tgt, uint8_t partial);
 void fpga_set_sddma_range(uint16_t start, uint16_t end);

--- a/src/main.c
+++ b/src/main.c
@@ -396,6 +396,14 @@ int main(void) {
           status_load_to_menu();
           cmd=0; /* stay in menu loop */
           break;
+        case SNES_CMD_SET_SLOTB_ROM:
+          get_selected_name(file_lfn);
+          printf("Set Slot B ROM: %s\n", file_lfn);
+          strncpy(slotb_filename, (char*)file_lfn, 257);
+          slotb_filename[257] = 0;
+          status_load_to_menu();
+          cmd=0; /* stay in menu loop, non-persistent */
+          break;
         case SNES_CMD_SET_AUTOBOOT_FAV:
           cfg_get_favorite_game(file_lfn, snes_get_mcu_param() & 0xff);
           printf("Set autoboot from favorite: %s\n", file_lfn);

--- a/src/memory.c
+++ b/src/memory.c
@@ -399,8 +399,8 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
         }
       }
     } else {
-      /* No Slot B: zero header region so BIOS rejects second cart */
-      sram_memset(0x600000, 0x100, 0x00);
+      /* No Slot B: zero header area so STBIOS cannot match "BANDAI SFC-ADX" signature */
+      sram_memset(0x600000, 0x40, 0x00);
       set_rom_mask_b(0);
     }
   }
@@ -434,7 +434,11 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
     /* Sufami Turbo Slot A: SRAM size from ST header byte 0x37, not standard header.
        When Slot B is present, bit 19 of SAVERAM_MASK separates Slot A (0xE00000)
        from Slot B SRAM (0xE80000). Use larger of the two masks for the window size. */
-    uint32_t slota_rammask = romprops.ramsize_bytes ? (romprops.ramsize_bytes - 1) : 0;
+    /* ST hardware always has a physical 8KB SRAM used by STBIOS as runtime RAM.
+       Games with no declared save SRAM (byte 0x37 == 0) still need the SRAM
+       accessible so the STBIOS can dispatch into it (e.g. $E0:$78F9). */
+    uint32_t slota_ramsize = (romprops.ramsize_bytes > 0x2000) ? romprops.ramsize_bytes : 0x2000;
+    uint32_t slota_rammask = slota_ramsize - 1;
     rammask = (slota_rammask > slotb_rammask) ? slota_rammask : slotb_rammask;
     if(slotb_rammask) rammask |= 0x80000;
   } else if(romprops.header.ramsize == 0) {
@@ -509,7 +513,8 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
   printf("done\n");
 
   printf("r213fen=%d is_u16=%d filename=%s\n", cfg_is_r213f_override_enabled(), STS.is_u16, filename);
-  if(cfg_is_r213f_override_enabled() && !is_menu && !STS.is_u16) {
+  if(cfg_is_r213f_override_enabled() && !is_menu && !STS.is_u16
+     && romprops.mapper_id != 5) { /* Sufami Turbo: STBIOS reads $213F for region detection; override breaks it */
     romprops.fpga_features |= FEAT_213F; /* e.g. for general consoles */
   }
   fpga_set_213f(romprops.region);

--- a/src/memory.c
+++ b/src/memory.c
@@ -515,8 +515,7 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
   printf("done\n");
 
   printf("r213fen=%d is_u16=%d filename=%s\n", cfg_is_r213f_override_enabled(), STS.is_u16, filename);
-  if(cfg_is_r213f_override_enabled() && !is_menu && !STS.is_u16
-     && romprops.mapper_id != 5) { /* Sufami Turbo: STBIOS reads $213F for region detection; override breaks it */
+  if(cfg_is_r213f_override_enabled() && !is_menu && !STS.is_u16) {
     romprops.fpga_features |= FEAT_213F; /* e.g. for general consoles */
   }
   fpga_set_213f(romprops.region);

--- a/src/memory.c
+++ b/src/memory.c
@@ -235,6 +235,7 @@ uint16_t sram_writeblock(void* buf, uint32_t addr, uint16_t size) {
 
 char current_filename[258];
 char slotb_filename[258];
+uint32_t slotb_ramsize_bytes = 0; /* Slot B SRAM size in bytes; 0 when no Slot B or no SRAM */
 uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
   UINT bytes_read;
   DWORD filesize;
@@ -389,6 +390,7 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
         /* Read Slot B SRAM size from ST header byte 0x37 (2KB units) */
         uint32_t slotb_ramsize = (uint32_t)sram_readbyte(0x600037) * 2048;
         slotb_rammask = slotb_ramsize ? (slotb_ramsize - 1) : 0;
+        slotb_ramsize_bytes = slotb_ramsize;
         /* Initialize Slot B SRAM region (0xE80000) and load from .srm file */
         if(slotb_ramsize) {
           sram_memset(0xE80000, slotb_ramsize, 0xFF);

--- a/src/memory.c
+++ b/src/memory.c
@@ -234,6 +234,7 @@ uint16_t sram_writeblock(void* buf, uint32_t addr, uint16_t size) {
 }
 
 char current_filename[258];
+char slotb_filename[258];
 uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
   UINT bytes_read;
   DWORD filesize;
@@ -364,14 +365,44 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
       set_fpga_time(get_bcdtime());
     }
   }
+  uint32_t slotb_rammask = 0;
   if(romprops.mapper_id==5) {
     printf("Sufami Turbo ROM\n");
     printf("Loading ST BIOS %s...\n", STBIOS_FW);
     load_sram_offload((uint8_t*)STBIOS_FW, 0x000000, LOADRAM_AUTOSKIP_HEADER);
     if(file_res) snes_menu_errmsg(MENU_ERR_SUPPLFILE, (void*)STBIOS_FW);
-    /* Zero Slot B header region (PSRAM 0x600000) so BIOS reads 0x00 there
-       and does not detect a spurious second cart (would trigger dual-cart wait) */
-    sram_memset(0x600000, 0x100, 0x00);
+    if(slotb_filename[0]) {
+      uint8_t slotb_buf[258];
+      strncpy((char*)slotb_buf, slotb_filename, sizeof(slotb_buf)-1);
+      slotb_buf[sizeof(slotb_buf)-1] = 0;
+      printf("Loading Slot B ROM %s...\n", slotb_buf);
+      uint32_t slotb_filesize = load_sram_offload(slotb_buf, 0x600000, LOADRAM_AUTOSKIP_HEADER);
+      if(file_res) {
+        printf("Slot B ROM load failed, disabling\n");
+        sram_memset(0x600000, 0x100, 0x00);
+        set_rom_mask_b(0);
+      } else {
+        /* Compute Slot B ROM mask: next power of 2 >= filesize */
+        uint32_t slotb_sz = 1;
+        while(slotb_sz < slotb_filesize) slotb_sz <<= 1;
+        set_rom_mask_b(slotb_sz - 1);
+        /* Read Slot B SRAM size from ST header byte 0x37 (2KB units) */
+        uint32_t slotb_ramsize = (uint32_t)sram_readbyte(0x600037) * 2048;
+        slotb_rammask = slotb_ramsize ? (slotb_ramsize - 1) : 0;
+        /* Initialize Slot B SRAM region (0xE80000) and load from .srm file */
+        if(slotb_ramsize) {
+          sram_memset(0xE80000, slotb_ramsize, 0xFF);
+          strncpy((char*)slotb_buf, slotb_filename, sizeof(slotb_buf)-1);
+          slotb_buf[sizeof(slotb_buf)-1] = 0;
+          migrate_and_load_srm(slotb_buf, 0xE80000);
+          if(file_res == FR_NO_FILE) file_res = 0;
+        }
+      }
+    } else {
+      /* No Slot B: zero header region so BIOS rejects second cart */
+      sram_memset(0x600000, 0x100, 0x00);
+      set_rom_mask_b(0);
+    }
   }
   if(romprops.has_dspx) {
     printf("DSPx game. Loading firmware image %s...\n", romprops.dsp_fw);
@@ -400,9 +431,12 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
     romprops.sramsize_bytes = romprops.ramsize_bytes;
     rammask = 1;
   } else if(romprops.mapper_id == 5) {
-    /* Sufami Turbo: SRAM size comes from ST header byte 0x37, not standard header.
-       header.ramsize is never populated for ST carts (early return in smc_id). */
-    rammask = romprops.ramsize_bytes ? (romprops.ramsize_bytes - 1) : 0;
+    /* Sufami Turbo Slot A: SRAM size from ST header byte 0x37, not standard header.
+       When Slot B is present, bit 19 of SAVERAM_MASK separates Slot A (0xE00000)
+       from Slot B SRAM (0xE80000). Use larger of the two masks for the window size. */
+    uint32_t slota_rammask = romprops.ramsize_bytes ? (romprops.ramsize_bytes - 1) : 0;
+    rammask = (slota_rammask > slotb_rammask) ? slota_rammask : slotb_rammask;
+    if(slotb_rammask) rammask |= 0x80000;
   } else if(romprops.header.ramsize == 0) {
     rammask = 0;
   } else {

--- a/src/memory.c
+++ b/src/memory.c
@@ -364,6 +364,15 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
       set_fpga_time(get_bcdtime());
     }
   }
+  if(romprops.mapper_id==5) {
+    printf("Sufami Turbo ROM\n");
+    printf("Loading ST BIOS %s...\n", STBIOS_FW);
+    load_sram_offload((uint8_t*)STBIOS_FW, 0x000000, LOADRAM_AUTOSKIP_HEADER);
+    if(file_res) snes_menu_errmsg(MENU_ERR_SUPPLFILE, (void*)STBIOS_FW);
+    /* Zero Slot B header region (PSRAM 0x600000) so BIOS reads 0x00 there
+       and does not detect a spurious second cart (would trigger dual-cart wait) */
+    sram_memset(0x600000, 0x100, 0x00);
+  }
   if(romprops.has_dspx) {
     printf("DSPx game. Loading firmware image %s...\n", romprops.dsp_fw);
     load_dspx(romprops.dsp_fw, romprops.fpga_features);
@@ -390,6 +399,10 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
     romprops.srambase       = 0;
     romprops.sramsize_bytes = romprops.ramsize_bytes;
     rammask = 1;
+  } else if(romprops.mapper_id == 5) {
+    /* Sufami Turbo: SRAM size comes from ST header byte 0x37, not standard header.
+       header.ramsize is never populated for ST carts (early return in smc_id). */
+    rammask = romprops.ramsize_bytes ? (romprops.ramsize_bytes - 1) : 0;
   } else if(romprops.header.ramsize == 0) {
     rammask = 0;
   } else {

--- a/src/memory.h
+++ b/src/memory.h
@@ -32,6 +32,7 @@
 
 extern char current_filename[];
 extern char slotb_filename[];
+extern uint32_t slotb_ramsize_bytes;
 
 #define MENU_ADDR_BRAM_SRC           (0xFF00)
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -31,6 +31,7 @@
 #include "smc.h"
 
 extern char current_filename[];
+extern char slotb_filename[];
 
 #define MENU_ADDR_BRAM_SRC           (0xFF00)
 

--- a/src/smc.c
+++ b/src/smc.c
@@ -65,6 +65,44 @@ void smc_id(snes_romprops_t* props, uint32_t file_offset) {
   uint8_t ext_coprocessor=0;
   snes_header_t* header = &(props->header);
 
+  /* Sufami Turbo detection: "BANDAI SFC-ADX" signature at byte 0 */
+  {
+    uint8_t st_hdr[0x40]; /* must be >= 0x38 to reach SRAM size at 0x37 */
+    file_readblock(st_hdr, file_offset, sizeof(st_hdr));
+    if(!memcmp(st_hdr, "BANDAI SFC-ADX", 14)) {
+      uint32_t sz = 1;
+      props->load_address   = 0x200000; /* Slot A ROM at physical PSRAM 0x200000 */
+      props->offset         = 0;
+      props->has_dspx       = 0;
+      props->has_st0010     = 0;
+      props->has_st0011     = 0;
+      props->has_st0018     = 0;
+      props->has_msu1       = 0;
+      props->has_spc7110    = 0;
+      props->has_cx4        = 0;
+      props->has_obc1       = 0;
+      props->has_gsu        = 0;
+      props->has_sa1        = 0;
+      props->has_sdd1       = 0;
+      props->has_combo      = 0;
+      props->srambase       = 0;
+      props->fpga_features  = 0;
+      props->fpga_dspfeat   = 0;
+      props->fpga_conf      = NULL;
+      while(sz < file_handle.fsize) sz <<= 1;
+      props->romsize_bytes    = sz;
+      /* ST header byte 0x37 = SRAM size in 2KB units (fullsnes spec) */
+      props->sramsize_bytes   = (uint32_t)st_hdr[0x37] * 2048;
+      props->ramsize_bytes    = props->sramsize_bytes;
+      props->expramsize_bytes = 0;
+      props->region           = 1; /* Japan only */
+      props->mapper_id        = 5; /* Sufami Turbo */
+      printf("Sufami Turbo: ROM=%ldKB SRAM=%ldKB\n",
+             sz >> 10, props->sramsize_bytes >> 10);
+      return;
+    }
+  }
+
   props->load_address = 0;
   props->has_dspx = 0;
   props->has_st0010 = 0;
@@ -432,4 +470,3 @@ uint8_t smc_headerscore(uint32_t addr, snes_header_t* header, uint32_t file_offs
   if(score < 0) score = 0;
   return score;
 }
-

--- a/src/smc.c
+++ b/src/smc.c
@@ -95,7 +95,7 @@ void smc_id(snes_romprops_t* props, uint32_t file_offset) {
       props->sramsize_bytes   = (uint32_t)st_hdr[0x37] * 2048;
       props->ramsize_bytes    = props->sramsize_bytes;
       props->expramsize_bytes = 0;
-      props->region           = 1; /* Japan only */
+      props->region           = 0; /* Japan only */
       props->mapper_id        = 5; /* Sufami Turbo */
       printf("Sufami Turbo: ROM=%ldKB SRAM=%ldKB\n",
              sz >> 10, props->sramsize_bytes >> 10);

--- a/src/smc.h
+++ b/src/smc.h
@@ -33,6 +33,7 @@
 #define DSPFW_4 ((const uint8_t*)"/sd2snes/dsp4.bin")
 #define DSPFW_1B ((const uint8_t*)"/sd2snes/dsp1b.bin")
 #define DSPFW_ST0010 ((const uint8_t*)"/sd2snes/st0010.bin")
+#define STBIOS_FW ((const uint8_t*)"/sd2snes/STBIOS.bin")
 
 typedef struct __attribute__ ((__packed__)) _snes_header {
   uint8_t maker[2];     /* 0xB0 */

--- a/src/snes.c
+++ b/src/snes.c
@@ -114,6 +114,11 @@ void prepare_reset() {
     save_srm(file_lfn, romprops.ramsize_bytes, SRAM_SAVE_ADDR);
     writeled(0);
   }
+  if(slotb_ramsize_bytes && fpga_test() == FPGA_TEST_TOKEN) {
+    writeled(1);
+    save_srm((uint8_t*)slotb_filename, slotb_ramsize_bytes, 0xE80000);
+    writeled(0);
+  }
   // don't save SGB RTC since we are in reset and it may be undefined
   rdyled(1);
   readled(1);
@@ -123,7 +128,8 @@ void prepare_reset() {
   snes_reset(1);
   fpga_dspx_reset(1);
   delay_ms(200);
-  slotb_filename[0] = 0; /* clear Slot B selection on every return-to-menu */
+  slotb_filename[0] = 0;     /* clear Slot B selection on every return-to-menu */
+  slotb_ramsize_bytes = 0;
 }
 
 void snes_init() {
@@ -314,6 +320,7 @@ uint8_t snes_main_loop() {
           printf("SaveRAM CRC: 0x%04lx; saving %s\n", saveram_crc, file_lfn);
           writeled(1);
           save_srm(file_lfn, romprops.ramsize_bytes, SRAM_SAVE_ADDR);
+          if(slotb_ramsize_bytes) save_srm((uint8_t*)slotb_filename, slotb_ramsize_bytes, 0xE80000);
           last_save_failed = save_failed;
           save_failed = file_res ? 1 : 0;
           didnotsave = save_failed ? 25 : 0;
@@ -324,6 +331,7 @@ uint8_t snes_main_loop() {
           diffcount=0;
           writeled(1);
           save_srm(file_lfn, romprops.ramsize_bytes, SRAM_SAVE_ADDR);
+          if(slotb_ramsize_bytes) save_srm((uint8_t*)slotb_filename, slotb_ramsize_bytes, 0xE80000);
           last_save_failed = save_failed;
           save_failed = file_res ? 1 : 0;
           didnotsave = save_failed ? 25 : 0;

--- a/src/snes.c
+++ b/src/snes.c
@@ -123,6 +123,7 @@ void prepare_reset() {
   snes_reset(1);
   fpga_dspx_reset(1);
   delay_ms(200);
+  slotb_filename[0] = 0; /* clear Slot B selection on every return-to-menu */
 }
 
 void snes_init() {

--- a/src/snes.h
+++ b/src/snes.h
@@ -48,6 +48,7 @@
 #define SNES_CMD_SET_AUTOBOOT_FAV    (0x16) /* set autoboot from favorites list (index in MCU_PARAM) */
 #define SNES_CMD_CLR_AUTOBOOT_ROM    (0x17) /* clear autoboot ROM setting */
 #define SNES_CMD_LOAD_AUTOBOOT       (0x18) /* boot into the stored autoboot ROM */
+#define SNES_CMD_SET_SLOTB_ROM       (0x19) /* set Slot B companion cart for Sufami Turbo (non-persistent) */
 
 #define SNES_CMD_SAVESTATE           (0x40)
 #define SNES_CMD_LOADSTATE           (0x41)

--- a/verilog/sd2snes_base/address.v
+++ b/verilog/sd2snes_base/address.v
@@ -116,6 +116,15 @@ assign IS_SAVERAM_pre = (~map_unlock & SAVERAM_MASK[0])
                       ? ((SNES_ADDR_early[23:19] == 5'b00010)
                          & (SNES_ADDR_early[15:12] == 4'b0101)
                         )
+/*  Sufami Turbo: Slot A SRAM @ Bank 0x60-0x63, Offset 0x8000-0xFFFF
+ *  Banks 0x60-0x63: A23=0,A22=1,A21=1,A20=0  (~A20 excludes Slot B SRAM 0x70-0x73) */
+                      :(MAPPER_DEC[3'b101])
+                      ? ((SNES_ADDR_early[22:21] == 2'b11)
+                         & ~SNES_ADDR_early[23]
+                         & ~SNES_ADDR_early[20]
+                         & SNES_ADDR_early[15]
+                         & (~SNES_ROMSEL)
+                        )
 /*  Menu mapper: 8Mbit "SRAM" @ Bank 0xf0-0xff (entire banks!) */
                       :(MAPPER_DEC[3'b111])
                       ? (&SNES_ADDR_early[23:20])
@@ -212,6 +221,17 @@ assign SRAM_SNES_ADDR = IS_PATCH
                               ? (24'h900000 + {bs_page,bs_page_offset})
                               : (BSX_ADDR & 24'h0fffff)
                            )
+                           :(MAPPER_DEC[3'b101])  // Sufami Turbo
+                           ?(IS_SAVERAM
+                             ? SAVERAM_ADDR + ({SNES_ADDR[20:16], SNES_ADDR[14:0]}
+                                             & SAVERAM_MASK)
+                             : (~SNES_ADDR[22] & ~SNES_ADDR[21]) // BIOS banks 00-1F, 80-9F
+                             ? ({6'b0, SNES_ADDR[18:16], SNES_ADDR[14:0]})
+                             : (~SNES_ADDR[22] &  SNES_ADDR[21]) // Slot A ROM banks 20-3F, A0-BF
+                             ? (24'h200000 | ({4'b0, SNES_ADDR[20:16], SNES_ADDR[14:0]}
+                                            & ROM_MASK))  // Slot A ROM at PSRAM 0x200000
+                             : (24'h600000 | {9'b0, SNES_ADDR[14:0]}) // Slot B absent: zeroed region, BIOS reads 0x00 != "BANDAI SFC-ADX"
+                            )
                            :(MAPPER_DEC[3'b110])
                            ?(IS_SAVERAM
                              ? SAVERAM_ADDR + ((SNES_ADDR[14:0] - 15'h6000)

--- a/verilog/sd2snes_base/address.v
+++ b/verilog/sd2snes_base/address.v
@@ -117,16 +117,12 @@ assign IS_SAVERAM_pre = (~map_unlock & SAVERAM_MASK[0])
                       ? ((SNES_ADDR_early[23:19] == 5'b00010)
                          & (SNES_ADDR_early[15:12] == 4'b0101)
                         )
-/*  Sufami Turbo: Slot A SRAM @ Bank 0x60-0x63, Slot B SRAM @ Bank 0x70-0x73, Offset 0x8000-0xFFFF
- *  Banks 0x60-0x63 (Slot A): A23=0,A22=1,A21=1,A20=0,A19=0,A18=0
- *  Banks 0x70-0x73 (Slot B): A23=0,A22=1,A21=1,A20=1,A19=0,A18=0
- *  Common guard: ~A19 & ~A18 selects both groups */
+/*  Sufami Turbo: Slot A SRAM @ Banks 0x60-0x6F (+mirrors 0xE0-0xEF), Slot B @ 0x70-0x7F (+0xF0-0xFF)
+ *  ROMSEL fires for full $0000-$FFFF in banks $60-$6F (and mirrors). The STBIOS dispatches
+ *  into SRAM at sub-$8000 offsets (e.g. $E0:$78F9), so no A15 guard and no ~A23 guard.
+ *  Match MiSTer SufamiMap: SRAM_BASE_SEL|SRAM_TURBO_SEL = CA[22:21]="11" & ~ROMSEL_N */
                       :(MAPPER_DEC[3'b101])
                       ? ((SNES_ADDR_early[22:21] == 2'b11)
-                         & ~SNES_ADDR_early[23]
-                         & ~SNES_ADDR_early[19]
-                         & ~SNES_ADDR_early[18]
-                         & SNES_ADDR_early[15]
                          & (~SNES_ROMSEL)
                         )
 /*  Menu mapper: 8Mbit "SRAM" @ Bank 0xf0-0xff (entire banks!) */

--- a/verilog/sd2snes_base/address.v
+++ b/verilog/sd2snes_base/address.v
@@ -34,6 +34,7 @@ module address(
   input [7:0] SAVERAM_BASE,
   input [23:0] SAVERAM_MASK,
   input [23:0] ROM_MASK,
+  input [23:0] ROM_MASK_B,
   input  map_unlock,
   input  map_Ex_rd_unlock,
   input  map_Ex_wr_unlock,
@@ -116,12 +117,15 @@ assign IS_SAVERAM_pre = (~map_unlock & SAVERAM_MASK[0])
                       ? ((SNES_ADDR_early[23:19] == 5'b00010)
                          & (SNES_ADDR_early[15:12] == 4'b0101)
                         )
-/*  Sufami Turbo: Slot A SRAM @ Bank 0x60-0x63, Offset 0x8000-0xFFFF
- *  Banks 0x60-0x63: A23=0,A22=1,A21=1,A20=0  (~A20 excludes Slot B SRAM 0x70-0x73) */
+/*  Sufami Turbo: Slot A SRAM @ Bank 0x60-0x63, Slot B SRAM @ Bank 0x70-0x73, Offset 0x8000-0xFFFF
+ *  Banks 0x60-0x63 (Slot A): A23=0,A22=1,A21=1,A20=0,A19=0,A18=0
+ *  Banks 0x70-0x73 (Slot B): A23=0,A22=1,A21=1,A20=1,A19=0,A18=0
+ *  Common guard: ~A19 & ~A18 selects both groups */
                       :(MAPPER_DEC[3'b101])
                       ? ((SNES_ADDR_early[22:21] == 2'b11)
                          & ~SNES_ADDR_early[23]
-                         & ~SNES_ADDR_early[20]
+                         & ~SNES_ADDR_early[19]
+                         & ~SNES_ADDR_early[18]
                          & SNES_ADDR_early[15]
                          & (~SNES_ROMSEL)
                         )
@@ -230,7 +234,7 @@ assign SRAM_SNES_ADDR = IS_PATCH
                              : (~SNES_ADDR[22] &  SNES_ADDR[21]) // Slot A ROM banks 20-3F, A0-BF
                              ? (24'h200000 | ({4'b0, SNES_ADDR[20:16], SNES_ADDR[14:0]}
                                             & ROM_MASK))  // Slot A ROM at PSRAM 0x200000
-                             : (24'h600000 | {9'b0, SNES_ADDR[14:0]}) // Slot B absent: zeroed region, BIOS reads 0x00 != "BANDAI SFC-ADX"
+                             : (24'h600000 | ({4'b0, SNES_ADDR[20:16], SNES_ADDR[14:0]} & ROM_MASK_B)) // Slot B ROM: ROM_MASK_B=0 → reads 0x600000 (zeroed, BIOS rejects)
                             )
                            :(MAPPER_DEC[3'b110])
                            ?(IS_SAVERAM

--- a/verilog/sd2snes_base/main.v
+++ b/verilog/sd2snes_base/main.v
@@ -108,6 +108,7 @@ wire [2:0] MAPPER;
 wire [7:0] SAVERAM_BASE;
 wire [23:0] SAVERAM_MASK;
 wire [23:0] ROM_MASK;
+wire [23:0] ROM_MASK_B;
 wire [7:0] SD_DMA_SRAM_DATA;
 wire [1:0] SD_DMA_TGT;
 wire [10:0] SD_DMA_PARTIAL_START;
@@ -621,6 +622,7 @@ mcu_cmd snes_mcu_cmd(
   .saveram_base_out(SAVERAM_BASE),
   .saveram_mask_out(SAVERAM_MASK),
   .rom_mask_out(ROM_MASK),
+  .rom_mask_b_out(ROM_MASK_B),
   .SD_DMA_EN(SD_DMA_EN),
   .SD_DMA_STATUS(SD_DMA_STATUS),
   .SD_DMA_NEXTADDR(SD_DMA_NEXTADDR),
@@ -693,6 +695,7 @@ address snes_addr(
   .SAVERAM_BASE(SAVERAM_BASE),
   .SAVERAM_MASK(SAVERAM_MASK),
   .ROM_MASK(ROM_MASK),
+  .ROM_MASK_B(ROM_MASK_B),
   .map_unlock(map_unlock),
   .map_Ex_rd_unlock(map_Ex_rd_unlock_r),
   .map_Ex_wr_unlock(map_Ex_wr_unlock_r),

--- a/verilog/sd2snes_base/mcu_cmd.v
+++ b/verilog/sd2snes_base/mcu_cmd.v
@@ -38,6 +38,7 @@ module mcu_cmd(
   output [7:0]  saveram_base_out,
   output [23:0] saveram_mask_out,
   output [23:0] rom_mask_out,
+  output [23:0] rom_mask_b_out,
 
   // SD "DMA" extension
   output SD_DMA_EN,
@@ -193,6 +194,7 @@ assign SD_DMA_PARTIAL_END = SD_DMA_PARTIAL_ENDr;
 reg [7:0]  SAVERAM_BASE; initial SAVERAM_BASE = 0;
 reg [23:0] SAVERAM_MASK;
 reg [23:0] ROM_MASK;
+reg [23:0] ROM_MASK_B; initial ROM_MASK_B = 0;
 
 assign spi_data_out = MCU_DATA_IN_BUF;
 
@@ -249,6 +251,15 @@ always @(posedge clk) begin
         endcase
       8'h4x:
         SD_DMA_ENr <= 1'b0;
+      8'h5x:
+        case (spi_byte_cnt)
+          32'h2:
+            ROM_MASK_B[23:16] <= param_data;
+          32'h3:
+            ROM_MASK_B[15:8] <= param_data;
+          32'h4:
+            ROM_MASK_B[7:0] <= param_data;
+        endcase
       8'h6x:
         case (spi_byte_cnt)
           32'h2: begin
@@ -586,6 +597,7 @@ assign srtc_reset = srtc_reset_buf;
 assign mcu_data_out = SD_DMA_STATUS ? SD_DMA_SRAM_DATA : MCU_DATA_OUT_BUF;
 assign mcu_mapper = MAPPER_BUF;
 assign rom_mask_out = ROM_MASK;
+assign rom_mask_b_out = ROM_MASK_B;
 assign saveram_mask_out = SAVERAM_MASK;
 assign saveram_base_out = SAVERAM_BASE;
 


### PR DESCRIPTION
- Adding support for Sufami Turbo.
- Adding Context menu entry for "Set as Slot B"
- Context only shows "Set as Slot B" for *.st files.
- All 13/13 ROMs work.

https://www.youtube.com/watch?v=qvCmDM35vIg

Requires STBIOS.bin in bin folder ( d3a44ba7d42a74d3ac58cb9c14c6a5ca ).

Known "issues":
- Same ST ROM **File** in Slot A and Slot B will overwrite with Save from Slot B. Same ROM with different filenames are fine.

Thanks for finding the ChinChan-Bug @terminator2k2
Thanks for the idea and testing @FixingGlobe