### PR TITLE
Feat: 8M Memory Pack support for slotted carts

### DIFF
--- a/src/fpga_spi.h
+++ b/src/fpga_spi.h
@@ -43,6 +43,8 @@
 #define FPGA_TX_BLOCK(x,y) spi_tx_block(x,y)
 #define FPGA_RX_BLOCK(x,y) spi_rx_block(x,y)
 
+#define FEAT_BSLOROM       (1 << 15)
+#define FEAT_BSSLOT        (1 << 14)
 #define FEAT_COMBO         (1 << 13)
 #define FEAT_SATELLABASE   (1 << 12)
 #define FEAT_DMA1          (1 << 11)

--- a/src/memory.c
+++ b/src/memory.c
@@ -58,6 +58,7 @@ extern snes_romprops_t romprops;
 extern uint32_t saveram_crc_old, saveram_crc, saveram_offset;
 extern uint32_t bs_pack_crc, bs_pack_crc_old, bs_pack_offset, bs_pack_diff, bs_pack_same,
                 bs_pack_didnotsave, bs_pack_save_failed;
+extern uint8_t bs_pack_erase_seq;
 static uint8_t rom_scan_bs_vendor(uint32_t size); /* BS slot auto-detect (defined below) */
 static uint8_t bs_pack_exists(uint8_t *filename);
 extern sgb_romprops_t sgb_romprops;
@@ -456,27 +457,44 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
     }
   }
 
-  /* BS Memory Pack slot, auto-detected (no title list): if a <rom>.mpk exists, scan the
-     ROM for the pack-probe signature.  Pre-gate to base core + mapper 0/1, and HiROM
-     <=2MB (above that its own ROM reaches $E0+, where the HiROM pack maps).  The window
-     follows the mapper (LoROM $C0-$DF / HiROM $E0-$EF).  FEAT_BSLOROM here for a >2MB
-     LoROM cart with a pack; standalone (no pack) boot of Derby/SN is in smc.c. */
-  if((flags & LOADROM_WITH_SRAM) && !romprops.fpga_conf
-     && (romprops.mapper_id == 1
-         || (romprops.mapper_id == 0 && romprops.romsize_bytes <= 0x200000))
-     && bs_pack_exists(filename)
-     && rom_scan_bs_vendor(romprops.romsize_bytes)) {
-    if(romprops.mapper_id == 1 && romprops.romsize_bytes > 0x200000) {
-      romprops.fpga_features |= FEAT_BSLOROM;
+  /* BS Memory Pack slot, auto-detected (no title list): needs a <rom>.mpk present.
+     Two families:
+       - base mapper (LoROM, or HiROM <=2MB; above that its own ROM reaches $E0+, where
+         the HiROM pack maps): confirm with the pack-probe ROM scan (LDA $bb:FF00/$bb:FF02).
+         The window follows the mapper (LoROM $C0-$DF / HiROM $E0-$EF).  FEAT_BSLOROM here
+         for a >2MB LoROM cart with a pack; standalone (no pack) boot of Derby/SN is in smc.c.
+       - SA-1 slotted (e.g. SD Gundam G Next): the game validates the pack on the S-CPU and
+         reads it through SuperMMC block 4 (the SA-1 core redirects MMC block>=4 to the pack
+         at PSRAM 0x900000).  It writes no flash registers, so there is no pack-probe
+         signature to scan -- gate on has_sa1 + a present .mpk (an explicit user action). */
+  uint8_t bs_slot = 0;
+  if((flags & LOADROM_WITH_SRAM) && bs_pack_exists(filename)) {
+    if(!romprops.fpga_conf
+       && (romprops.mapper_id == 1
+           || (romprops.mapper_id == 0 && romprops.romsize_bytes <= 0x200000))
+       && rom_scan_bs_vendor(romprops.romsize_bytes)) {
+      if(romprops.mapper_id == 1 && romprops.romsize_bytes > 0x200000) {
+        romprops.fpga_features |= FEAT_BSLOROM;
+      }
+      bs_slot = 1;
+    } else if(romprops.has_sa1) {
+      bs_slot = 1;
     }
-    if(load_bs_pack(filename)) {
-      printf("BS Memory Pack present\n");
-      romprops.fpga_features |= FEAT_BSSLOT;
-      /* seed the autosave baseline + reset scan state per game (globals, like
-         saveram_offset) so an unchanged pack is not re-written */
-      bs_pack_crc_old = calc_sram_crc(BS_PACK_ADDR, BS_PACK_SIZE, 0);
-      bs_pack_crc = bs_pack_offset = bs_pack_diff = bs_pack_same = 0;
-      bs_pack_didnotsave = bs_pack_save_failed = 0;
+  }
+  if(bs_slot && load_bs_pack(filename)) {
+    printf("BS Memory Pack present\n");
+    romprops.fpga_features |= FEAT_BSSLOT;
+    /* seed the autosave baseline + reset scan state per game (globals, like
+       saveram_offset) so an unchanged pack is not re-written */
+    bs_pack_crc_old = calc_sram_crc(BS_PACK_ADDR, BS_PACK_SIZE, 0);
+    bs_pack_crc = bs_pack_offset = bs_pack_diff = bs_pack_same = 0;
+    bs_pack_didnotsave = bs_pack_save_failed = 0;
+    /* sync the erase seq to the FPGA's current value so a stale seq from a previous
+       game doesn't trigger a spurious erase on the first poll */
+    bs_pack_erase_seq = (fpga_status() >> 11) & 0x3;
+    /* RTC is the Satellaview base-unit clock (base core only); the SA-1 core has no
+       BS-X base regs, so don't poke the FPGA time there. */
+    if(!romprops.has_sa1) {
       if(CFG.bsx_use_usertime) {
         set_fpga_time(srtctime2bcdtime(CFG.bsx_time));
       } else {

--- a/src/memory.c
+++ b/src/memory.c
@@ -56,6 +56,10 @@ char* hex = "0123456789ABCDEF";
 
 extern snes_romprops_t romprops;
 extern uint32_t saveram_crc_old, saveram_crc, saveram_offset;
+extern uint32_t bs_pack_crc, bs_pack_crc_old, bs_pack_offset, bs_pack_diff, bs_pack_same,
+                bs_pack_didnotsave, bs_pack_save_failed;
+static uint8_t rom_scan_bs_vendor(uint32_t size); /* BS slot auto-detect (defined below) */
+static uint8_t bs_pack_exists(uint8_t *filename);
 extern sgb_romprops_t sgb_romprops;
 extern uint32_t saveram_crc_old;
 extern uint8_t sram_crc_valid;
@@ -452,6 +456,35 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
     }
   }
 
+  /* BS Memory Pack slot, auto-detected (no title list): if a <rom>.mpk exists, scan the
+     ROM for the pack-probe signature.  Pre-gate to base core + mapper 0/1, and HiROM
+     <=2MB (above that its own ROM reaches $E0+, where the HiROM pack maps).  The window
+     follows the mapper (LoROM $C0-$DF / HiROM $E0-$EF).  FEAT_BSLOROM here for a >2MB
+     LoROM cart with a pack; standalone (no pack) boot of Derby/SN is in smc.c. */
+  if((flags & LOADROM_WITH_SRAM) && !romprops.fpga_conf
+     && (romprops.mapper_id == 1
+         || (romprops.mapper_id == 0 && romprops.romsize_bytes <= 0x200000))
+     && bs_pack_exists(filename)
+     && rom_scan_bs_vendor(romprops.romsize_bytes)) {
+    if(romprops.mapper_id == 1 && romprops.romsize_bytes > 0x200000) {
+      romprops.fpga_features |= FEAT_BSLOROM;
+    }
+    if(load_bs_pack(filename)) {
+      printf("BS Memory Pack present\n");
+      romprops.fpga_features |= FEAT_BSSLOT;
+      /* seed the autosave baseline + reset scan state per game (globals, like
+         saveram_offset) so an unchanged pack is not re-written */
+      bs_pack_crc_old = calc_sram_crc(BS_PACK_ADDR, BS_PACK_SIZE, 0);
+      bs_pack_crc = bs_pack_offset = bs_pack_diff = bs_pack_same = 0;
+      bs_pack_didnotsave = bs_pack_save_failed = 0;
+      if(CFG.bsx_use_usertime) {
+        set_fpga_time(srtctime2bcdtime(CFG.bsx_time));
+      } else {
+        set_fpga_time(get_bcdtime());
+      }
+    }
+  }
+
   printf("check MSU...");
   if(msu1_check(filename)) {
     romprops.fpga_features |= FEAT_MSU1;
@@ -759,11 +792,74 @@ uint32_t load_bootrle(uint32_t base_addr) {
   return (uint32_t)filesize;
 }
 
+/* is there a <rom>.mpk?  cheap f_stat that gates the ROM scan below */
+static uint8_t bs_pack_exists(uint8_t *filename) {
+  uint8_t bsfile[256] = SAVE_BASEDIR;
+  FILINFO fno;
+  append_file_basename((char*)bsfile, (char*)filename, ".mpk", sizeof(bsfile));
+  fno.lfname = NULL;
+  return f_stat((TCHAR*)bsfile, &fno) == FR_OK;
+}
+
+/* BS slot auto-detect: scan the staged ROM for the pack-probe vendor read
+   (LDA $bb:FF00 then LDA $bb:FF02 within 24 bytes, bb>=$C0).  Returns the vendor bank
+   ($C0/$C1 LoROM, $E0 HiROM) or 0.  SA-1 / normal carts have no such pattern.  SNES is
+   in reset during load, so the raw PSRAM read is stable. */
+static uint8_t rom_scan_bs_vendor(uint32_t size) {
+  uint8_t w0=0, w1=0, w2=0, w3=0; /* sliding 4-byte window, w3 = newest */
+  uint8_t pend=0; uint16_t cd=0;  /* pending AF 00 FF bb + countdown to its $FF02 */
+  uint8_t found=0;
+  set_mcu_addr(0);
+  FPGA_SELECT();
+  FPGA_TX_BYTE(FPGA_CMD_READMEM | FPGA_MEM_AUTOINC);
+  for(uint32_t i=0; i<size; i++) {
+    FPGA_WAIT_RDY();
+    w0=w1; w1=w2; w2=w3; w3=FPGA_RX_BYTE();
+    if(w0==0xAF && w2==0xFF && w3>=0xC0) {
+      if(w1==0x00) { pend=w3; cd=24; }
+      else if(w1==0x02 && cd && w3==pend) { found=w3; break; }
+    }
+    if(cd) cd--;
+  }
+  FPGA_DESELECT();
+  return found;
+}
+
 void save_srm(uint8_t* filename, uint32_t sram_size, uint32_t base_addr) {
     char srmfile[256] = SAVE_BASEDIR;
     check_or_create_folder(SAVE_BASEDIR);
     append_file_basename(srmfile, (char*)filename, ".srm", sizeof(srmfile));
     save_sram((uint8_t*)srmfile, sram_size, base_addr);
+}
+
+/* stage <rom>.mpk into PSRAM at BS_PACK_ADDR.  returns 1 if a pack loaded, 0 = empty
+   slot (no file -> nothing mapped, game boots standalone).  .mpk not .bs (.bs is a
+   bootable BS-X ROM type in the browser). */
+uint8_t load_bs_pack(uint8_t* filename) {
+  uint8_t bsfile[256] = SAVE_BASEDIR;
+  FILINFO fno;
+  append_file_basename((char*)bsfile, (char*)filename, ".mpk", sizeof(bsfile));
+  fno.lfname = NULL;
+  if(f_stat((TCHAR*)bsfile, &fno) != FR_OK) {
+    printf("no pack (%s); empty slot\n", bsfile);
+    return 0;
+  }
+  printf("BS pack file: %s\n", bsfile);
+  load_sram(bsfile, BS_PACK_ADDR);
+  /* clear only the tail past a short .mpk (a full 1MB one overwrites the window) */
+  if(fno.fsize < BS_PACK_SIZE) {
+    sram_memset(BS_PACK_ADDR + fno.fsize, BS_PACK_SIZE - fno.fsize, 0x00);
+  }
+  file_res = 0;
+  printf("pack loaded\n");
+  return 1;
+}
+
+void save_bs_pack(uint8_t* filename) {
+  char bsfile[256] = SAVE_BASEDIR;
+  check_or_create_folder(SAVE_BASEDIR);
+  append_file_basename(bsfile, (char*)filename, ".mpk", sizeof(bsfile));
+  save_sram((uint8_t*)bsfile, BS_PACK_SIZE, BS_PACK_ADDR);
 }
 
 void save_sram(uint8_t* filename, uint32_t sram_size, uint32_t base_addr) {
@@ -814,6 +910,21 @@ uint32_t calc_sram_crc(uint32_t base_addr, uint32_t size, uint32_t crc) {
       break;
     }
     crc = crc32_update(crc, data);
+  }
+  FPGA_DESELECT();
+  return crc;
+}
+
+/* CRC the 1MB pack -- like calc_sram_crc but no get_snes_reset bail (prepare_reset
+   holds the SNES in reset, so the read is stable) */
+uint32_t calc_pack_crc_inreset(void) {
+  uint32_t crc = 0;
+  set_mcu_addr(BS_PACK_ADDR);
+  FPGA_SELECT();
+  FPGA_TX_BYTE(FPGA_CMD_READMEM | FPGA_MEM_AUTOINC);
+  for(uint32_t i = 0; i < BS_PACK_SIZE; i++) {
+    FPGA_WAIT_RDY();
+    crc = crc32_update(crc, FPGA_RX_BYTE());
   }
   FPGA_DESELECT();
   return crc;

--- a/src/memory.h
+++ b/src/memory.h
@@ -108,4 +108,12 @@ uint16_t calc_sram_sum(uint32_t base_addr, uint32_t size);
 uint8_t sram_reliable(void);
 void sram_memset(uint32_t base_addr, uint32_t len, uint8_t val);
 
+/* BS 8M Memory Pack: 1MB in PSRAM at 0x900000, mapped LoROM $C0-$DF / HiROM $E0-$EF
+   when FEAT_BSSLOT is set (0x900000 must match BS_PACK_HIT in address.v).  SD: .mpk */
+#define BS_PACK_ADDR  0x900000
+#define BS_PACK_SIZE  0x100000
+uint8_t load_bs_pack(uint8_t* filename);  /* returns 1 if a real pack was loaded */
+void save_bs_pack(uint8_t* filename);
+uint32_t calc_pack_crc_inreset(void);     /* reset-tolerant pack CRC for prepare_reset */
+
 #endif

--- a/src/smc.c
+++ b/src/smc.c
@@ -60,6 +60,26 @@ uint8_t checkChksum(uint16_t cchk, uint16_t chk) {
   return res;
 }
 
+/* Carts needing the $80-$9F -> upper-1MB boot remap (FEAT_BSLOROM) -- they run code
+   there and must boot with no pack, so it can't be auto-detected (a normal >2MB LoROM
+   RPG has the same header).  Derby (reset JML $80:854D), Sound Novel (SPC driver from
+   $8C:FE00).  The pack itself is auto-detected at load (memory.c), no list. */
+static int smc_needs_bslorom(const uint8_t *name) {
+  static const char *const tbl[] = {
+    "DERBY STALLION 96",
+    "SOUND NOVEL-TCOOL",
+  };
+  for(unsigned t = 0; t < sizeof(tbl) / sizeof(tbl[0]); t++) {
+    const char *want = tbl[t];
+    unsigned i;
+    for(i = 0; want[i]; i++) {
+      if((uint8_t)want[i] != name[i]) break;
+    }
+    if(!want[i]) return 1; /* whole prefix matched */
+  }
+  return 0;
+}
+
 void smc_id(snes_romprops_t* props, uint32_t file_offset) {
   uint8_t score, maxscore=1, score_idx=2; /* assume LoROM */
   uint8_t ext_coprocessor=0;
@@ -294,7 +314,13 @@ void smc_id(snes_romprops_t* props, uint32_t file_offset) {
     props->has_combo = 1;
     props->fpga_features |= FEAT_COMBO;
   }
-  
+
+  /* $80-$9F boot remap for the listed LoROM slot carts (see smc_needs_bslorom).
+     The pack window itself is auto-detected at load in memory.c. */
+  if(props->mapper_id == 1 && !props->fpga_conf && smc_needs_bslorom(header->name)) {
+    props->fpga_features |= FEAT_BSLOROM;
+  }
+
   if(header->romsize == 0 || header->romsize > 13) {
     props->romsize_bytes = 1024;
     header->romsize = 0;

--- a/src/snes.c
+++ b/src/snes.c
@@ -47,6 +47,9 @@
 #include "hwinfo.h"
 
 uint32_t saveram_crc, saveram_crc_old;
+uint32_t bs_pack_crc, bs_pack_crc_old; /* BS Memory Pack autosave */
+/* pack autosave scan state (globals so load_rom resets them per game) */
+uint32_t bs_pack_offset, bs_pack_diff, bs_pack_same, bs_pack_didnotsave, bs_pack_save_failed;
 uint8_t sram_crc_valid;
 uint8_t sram_crc_init;
 uint32_t sram_crc_romsize;
@@ -113,6 +116,19 @@ void prepare_reset() {
     writeled(1);
     save_srm(file_lfn, romprops.ramsize_bytes, SRAM_SAVE_ADDR);
     writeled(0);
+  }
+  /* save the pack only if it changed (CRC vs the last-saved baseline) -- no 1MB write
+     of an unchanged pack on every reset.  calc_pack_crc_inreset reads raw since the
+     SNES is in reset (calc_sram_crc would bail). */
+  if((romprops.fpga_features & FEAT_BSSLOT) && fpga_test() == FPGA_TEST_TOKEN) {
+    uint32_t crc = calc_pack_crc_inreset();
+    if(crc != bs_pack_crc_old) {
+      writeled(1);
+      save_bs_pack(file_lfn);
+      bs_pack_crc_old = crc;
+      bs_pack_diff = 0;
+      writeled(0);
+    }
   }
   // don't save SGB RTC since we are in reset and it may be undefined
   rdyled(1);
@@ -343,6 +359,57 @@ uint8_t snes_main_loop() {
     saveram_offset = 0;
     saveram_crc_old = 0;
     saveram_crc = 0;
+  }
+
+  /* pack autosave: same chunked-CRC scan as SaveRAM above, over the 1MB pack.
+     bs_pack_crc_old is seeded at load so an unchanged pack isn't rewritten. */
+  if((romprops.fpga_features & FEAT_BSSLOT) && CFG.enable_autosave) {
+    uint32_t crc_bytes = min(BS_PACK_SIZE - bs_pack_offset, SRAM_REGION_SIZE);
+    bs_pack_crc = calc_sram_crc(BS_PACK_ADDR + bs_pack_offset, crc_bytes, bs_pack_crc);
+    bs_pack_offset += crc_bytes;
+    if(crc_valid && sram_reliable()) {
+      if(bs_pack_offset >= BS_PACK_SIZE) {
+        if(bs_pack_save_failed) bs_pack_didnotsave++;
+        if(bs_pack_crc != bs_pack_crc_old) {
+          bs_pack_diff = 1;          /* dirty since last save */
+          bs_pack_same = 0;
+          bs_pack_didnotsave++;
+        } else if(bs_pack_diff) {
+          bs_pack_same++;            /* dirty but stable this pass */
+        }
+        if(bs_pack_diff && bs_pack_same >= 5) {
+          printf("BS pack CRC: 0x%04lx; saving %s\n", bs_pack_crc, file_lfn);
+          writeled(1);
+          save_bs_pack(file_lfn);
+          bs_pack_save_failed = file_res ? 1 : 0;
+          if(!bs_pack_save_failed) { bs_pack_diff = 0; bs_pack_same = 0; }
+          bs_pack_didnotsave = bs_pack_save_failed ? 25 : 0;
+          writeled(0);
+        }
+        if(bs_pack_didnotsave > 50) {
+          printf("BS pack periodic save (pack keeps changing or a save failed)\n");
+          writeled(1);
+          save_bs_pack(file_lfn);
+          bs_pack_save_failed = file_res ? 1 : 0;
+          if(!bs_pack_save_failed) bs_pack_diff = 0;
+          bs_pack_didnotsave = bs_pack_save_failed ? 25 : 0;
+          writeled(0);
+        }
+        bs_pack_offset = 0;
+        bs_pack_crc_old = bs_pack_crc;
+        bs_pack_crc = 0;
+      }
+    } else {
+      bs_pack_offset = 0;
+      bs_pack_crc = 0;
+    }
+  } else {
+    /* reset the scan, but keep bs_pack_crc_old: prepare_reset compares against it
+       (zeroing it, like SaveRAM does, would force a full flush every reset) */
+    bs_pack_offset = 0;
+    bs_pack_crc = 0;
+    bs_pack_same = 0;
+    bs_pack_didnotsave = 0;
   }
 
   return snes_get_mcu_cmd();

--- a/src/snes.c
+++ b/src/snes.c
@@ -50,6 +50,7 @@ uint32_t saveram_crc, saveram_crc_old;
 uint32_t bs_pack_crc, bs_pack_crc_old; /* BS Memory Pack autosave */
 /* pack autosave scan state (globals so load_rom resets them per game) */
 uint32_t bs_pack_offset, bs_pack_diff, bs_pack_same, bs_pack_didnotsave, bs_pack_save_failed;
+uint8_t bs_pack_erase_seq; /* last-seen FPGA flash-erase seq counter (status bits12-11) */
 uint8_t sram_crc_valid;
 uint8_t sram_crc_init;
 uint32_t sram_crc_romsize;
@@ -359,6 +360,25 @@ uint8_t snes_main_loop() {
     saveram_offset = 0;
     saveram_crc_old = 0;
     saveram_crc = 0;
+  }
+
+  /* BS pack flash erase: the FPGA flips status-word bit12 when the game issues a block
+     erase ($20/$D0) or chip erase ($A7/$D0).  The FPGA can't do a 64KB fill, so the MCU
+     does it: fill the block (bits 11..8) -- or the whole pack (bit7) -- with 0xFF.  Runs
+     independent of autosave so delete works regardless; the change then rides the
+     autosave path below to persist.  bs_pack_erase_toggle is synced at load. */
+  if(romprops.fpga_features & FEAT_BSSLOT) {
+    uint16_t bs_st = fpga_status();
+    uint8_t seq = (bs_st >> 11) & 0x3;       /* status bits 12-11 */
+    if(seq != bs_pack_erase_seq) {
+      bs_pack_erase_seq = seq;
+      uint8_t blk = ((bs_st >> 8) & 0x7) | (((bs_st >> 7) & 1) << 3); /* bits 10-8 + bit7 */
+      if(blk == 0xF) {
+        sram_memset(BS_PACK_ADDR, BS_PACK_SIZE, 0xFF);     /* chip erase */
+      } else {
+        sram_memset(BS_PACK_ADDR + ((uint32_t)blk << 16), 0x10000, 0xFF);
+      }
+    }
   }
 
   /* pack autosave: same chunked-CRC scan as SaveRAM above, over the 1MB pack.

--- a/src/ymodem.c
+++ b/src/ymodem.c
@@ -32,7 +32,7 @@ void ymodem_rxfile(FIL* fil) {
   UINT written;
   FRESULT res = FR_OK;
   uint16_t crc = 0, crc_sender;
-  uint32_t filesize, remaining = 0;
+  uint32_t filesize = 0, remaining = 0;
   int have_filesize = 0, first_block = 1;
   uart_flush();
 restart:

--- a/verilog/sd2snes_base/address.v
+++ b/verilog/sd2snes_base/address.v
@@ -68,12 +68,25 @@ parameter [3:0]
   FEAT_213F = 4,
   FEAT_SNESUNLOCK = 5,
   FEAT_2100 = 6,
-  FEAT_DMA1 = 11
+  FEAT_DMA1 = 11,
+  FEAT_BSSLOT = 14,
+  FEAT_BSLOROM = 15
 ;
 
 integer i;
 reg [7:0] MAPPER_DEC; always @(posedge CLK) for (i = 0; i < 8; i = i + 1) MAPPER_DEC[i] <= (MAPPER == i);
 reg [23:0] SNES_ADDR; always @(posedge CLK) SNES_ADDR <= SNES_ADDR_early;
+
+// BS Memory Pack: 8M pack at PSRAM 0x900000 (FEAT_BSSLOT)
+wire BS_SLOT = featurebits[FEAT_BSSLOT];
+wire [19:0] LOROM_OFF = {SNES_ADDR[20:16], SNES_ADDR[14:0]};
+wire BS_PACK_HIT    = BS_SLOT & (SNES_ADDR[23:21] == 3'b110); // LoROM pack $C0-$DF
+wire BS_PACK_HIT_HI = BS_SLOT & (SNES_ADDR[23:20] == 4'he);   // HiROM pack $E0-$EF
+
+// BS-LOROM (Derby): $80-$9F map to the upper 1MB (file $200000+), not $00-$1F
+wire BSLOROM = featurebits[FEAT_BSLOROM];
+wire BSLOROM_HI = BSLOROM & (SNES_ADDR[23:21] == 3'b100); // $80-$9F only
+wire [23:0] BSLOROM_ADDR = 24'h200000 + {4'b0, LOROM_OFF};
 
 wire [23:0] SRAM_SNES_ADDR;
 wire [23:0] SAVERAM_ADDR = {4'hE,1'b0,SAVERAM_BASE,11'h0};
@@ -186,12 +199,18 @@ assign SRAM_SNES_ADDR = IS_PATCH
                           ?(IS_SAVERAM
                             ? SAVERAM_ADDR + ({SNES_ADDR[20:16], SNES_ADDR[12:0]}
                                             & SAVERAM_MASK)
+                            : BS_PACK_HIT_HI                        /* HiROM pack: $En:0000 -> bank*$10000 */
+                            ? (24'h900000 + {4'h0, SNES_ADDR[19:0]})
                             : ({1'b0, SNES_ADDR[22:0]} & ROM_MASK))
 
                           :(MAPPER_DEC[3'b001])
                           ?(IS_SAVERAM
                             ? SAVERAM_ADDR + ({SNES_ADDR[20:16], SNES_ADDR[14:0]}
                                             & SAVERAM_MASK)
+                            : BS_PACK_HIT                          /* LoROM pack: $Cn:8000 -> bank*$8000 */
+                            ? (24'h900000 + {4'h0, LOROM_OFF})
+                            : BSLOROM_HI
+                            ? (BSLOROM_ADDR & ROM_MASK)
                             : ({1'b0, ~SNES_ADDR[23], SNES_ADDR[22:16], SNES_ADDR[14:0]}
                                & ROM_MASK))
 
@@ -239,7 +258,9 @@ assign ROM_HIT = IS_ROM | IS_WRITABLE | bs_page_enable;
 
 assign msu_enable = featurebits[FEAT_MSU1] & (!SNES_ADDR[22] && ((SNES_ADDR[15:0] & 16'hfff8) == 16'h2000));
 assign dma_enable = (featurebits[FEAT_DMA1] | map_unlock | snescmd_unlock) & (!SNES_ADDR[22] && ((SNES_ADDR[15:0] & 16'hfff0) == 16'h2020));
-assign use_bsx = (MAPPER_DEC[3'b011]);
+/* bsx.v flash FSM: on for the BS-X base cart (mapper 3) or a slot with a pack
+   (FEAT_BSSLOT, set only when a .mpk exists).  No pack -> off -> empty slot. */
+assign use_bsx = (MAPPER_DEC[3'b011]) | featurebits[FEAT_BSSLOT];
 assign srtc_enable = featurebits[FEAT_SRTC] & (!SNES_ADDR[22] && ((SNES_ADDR[15:0] & 16'hfffe) == 16'h2800));
 assign exe_enable =                           (!SNES_ADDR[22] && ((SNES_ADDR[15:0] & 16'hffff) == 16'h2C00));
 assign map_enable =                           (!SNES_ADDR[22] && ((SNES_ADDR[15:0] & 16'hffff) == 16'h2BB2));

--- a/verilog/sd2snes_base/bsx.v
+++ b/verilog/sd2snes_base/bsx.v
@@ -31,6 +31,8 @@ module bsx(
   output [14:0] regs_out,
   input pgm_we,
   input use_bsx,
+  input bs_slot,    // slotted cart: pack only, no MCC.  LoROM slot -> flash $C0-$DF
+  input bs_hirom,   // HiROM slot -> window $E0-$EF
   output data_ovr,
   output flash_writable,
   input [59:0] rtc_data_in,
@@ -63,16 +65,22 @@ reg flash_we_r;
 reg flash_status_r = 0;
 reg [7:0] flash_cmd0;
 
-wire cart_enable = (use_bsx) && ((snes_addr[23:12] & 12'hf0f) == 12'h005);
+// MCC registers (00-0f:5xxx) exist only on the BS-X base cart, never on a
+// slotted cart -> gate them off in slot mode so the game's low banks are free.
+wire cart_enable = (use_bsx) && ~bs_slot && ((snes_addr[23:12] & 12'hf0f) == 12'h005);
 
 wire base_enable = feat_bs_base_enable
                    & (use_bsx) && (!snes_addr[22] && (snes_addr[15:0] >= 16'h2188)
                                  && (snes_addr[15:0] <= 16'h219f));
 
-wire flash_enable = (snes_addr[23:16] == 8'hc0);
+// flash window: base $C0, LoROM slot $C0-$DF, HiROM slot $E0-$EF
+wire flash_enable = bs_hirom
+                    ? (snes_addr[23:20] == 4'he)
+                    : ((snes_addr[23:16] == 8'hc0)
+                       | (bs_slot & (snes_addr[23:21] == 3'b110)));
 
-wire flash_ovr = (use_bsx)
-                 && (flash_enable & flash_ovr_r);
+// command/vendor mode returns the register; array mode ($FF) reads PSRAM
+wire flash_ovr = (use_bsx) && (flash_enable & flash_ovr_r);
 
 assign flash_writable = (use_bsx)
                         && flash_enable
@@ -317,27 +325,28 @@ always @(posedge clkin) begin
       default:
         base_regs[base_addr] <= reg_data_in;
     endcase
-  end else if(reg_we_rising && flash_enable && regs_outr[4'hc]) begin
-    flash_we_r <= 0;
-    case(flash_addr)
-      16'h0000: begin
-        flash_cmd0 <= reg_data_in;
-        if((flash_cmd0 == 8'h72 && reg_data_in == 8'h75) & ~flash_we_r) begin
-          flash_ovr_r <= 1;
-          flash_status_r <= 0;
-        end else if((reg_data_in == 8'hff) & ~flash_we_r) begin
-          flash_ovr_r <= 0;
-          flash_we_r <= 0;
-        end else if(reg_data_in[7:1] == 7'b0111000 || ((flash_cmd0 == 8'h38 && reg_data_in == 8'hd0) & ~flash_we_r)) begin
-          flash_ovr_r <= 1;
-          flash_status_r <= 1;
-        end else if((reg_data_in == 8'h10) & ~flash_we_r) begin
-          flash_ovr_r <= 1;
-          flash_status_r <= 1;
-          flash_we_r <= 1;
-        end
+  end else if(reg_we_rising && flash_enable && (regs_outr[4'hc] | bs_slot)) begin
+    if(flash_we_r) begin
+      flash_we_r <= 0;  // data phase after $10: program byte, not a command
+    end else if(bs_hirom ? ((snes_addr[23:16] == 8'he0) && (flash_addr[14:0] == 15'h0000))
+                : bs_slot ? ((snes_addr[23:16] == 8'hc0) && (flash_addr[14:0] == 15'h0000))
+                : (flash_addr == 16'h0000)) begin
+      // command port: base $C0:0000 exact, LoROM slot $C0:0000/8000, HiROM slot $E0:0000
+      flash_cmd0 <= reg_data_in;
+      if(flash_cmd0 == 8'h72 && reg_data_in == 8'h75) begin
+        flash_ovr_r <= 1;
+        flash_status_r <= 0;
+      end else if(reg_data_in == 8'hff) begin
+        flash_ovr_r <= 0;
+      end else if(reg_data_in[7:1] == 7'b0111000 || (flash_cmd0 == 8'h38 && reg_data_in == 8'hd0)) begin
+        flash_ovr_r <= 1;
+        flash_status_r <= 1;
+      end else if(reg_data_in == 8'h10) begin
+        flash_ovr_r <= 1;
+        flash_status_r <= 1;
+        flash_we_r <= 1;
       end
-    endcase
+    end
   end
 end
 `endif

--- a/verilog/sd2snes_base/bsx.v
+++ b/verilog/sd2snes_base/bsx.v
@@ -39,7 +39,12 @@ module bsx(
   output [9:0] bs_page_out, // support only page 0000-03ff
   output bs_page_enable,
   output [8:0] bs_page_offset,
-  input feat_bs_base_enable
+  input feat_bs_base_enable,
+  // Flash erase request to the MCU (the FPGA can't fill 64KB; the MCU does the
+  // sram_memset(0xFF)).  bs_erase_seq increments on each erase; the MCU compares it
+  // to its last-seen value and erases bs_erase_blk (0xF = whole pack).
+  output [1:0] bs_erase_seq,
+  output [3:0] bs_erase_blk
 );
 
 `define BSX_ENABLE
@@ -82,11 +87,28 @@ wire flash_enable = bs_hirom
 // command/vendor mode returns the register; array mode ($FF) reads PSRAM
 wire flash_ovr = (use_bsx) && (flash_enable & flash_ovr_r);
 
+// program data phase; main.v does the write (skips $FF) via the copier path
 assign flash_writable = (use_bsx)
                         && flash_enable
                         && flash_we_r;
 
 assign data_ovr = (cart_enable | base_enable | flash_ovr) & ~bs_page_enable;
+
+// --- Flash block-erase tracking -------------------------------------------
+// block-erase = $20 (setup) then $D0 (confirm) at the block address.
+// 64KB blocks: HiROM bank $E0+blk, LoROM 2 banks/block ($C0+2*blk).
+reg erase_setup_r = 0;      // saw $20 (block erase setup)
+reg erase_all_setup_r = 0;  // saw $A7 (chip/all erase setup)
+// a delete can fire several erases, so a 1-bit toggle would alias -> 2-bit seq the
+// MCU compares (any change = erase).  bs_erase_blk = last block, 0xF = whole pack.
+reg [1:0] bs_erase_seq_r = 0;
+reg [3:0] bs_erase_blk_r = 0;
+assign bs_erase_seq = bs_erase_seq_r;
+assign bs_erase_blk = bs_erase_blk_r;
+wire [3:0] erase_blk_of_addr = bs_hirom ? snes_addr[19:16] : snes_addr[20:17];
+// busy timer held after a $D0 so the game waits while the MCU erases the block (~0.4s)
+reg [24:0] erase_busy_cnt = 0;
+wire erase_busy = (erase_busy_cnt != 0);
 
 
 reg [9:0] bs_page0;
@@ -236,6 +258,7 @@ initial begin
 end
 
 always @(posedge clkin) begin
+  if(erase_busy_cnt != 0) erase_busy_cnt <= erase_busy_cnt - 1'b1;  // WSM busy timer (a $D0 reloads it below)
   if(reg_oe_rising && base_enable) begin
     case(base_addr)
       5'h0b: begin
@@ -278,14 +301,16 @@ always @(posedge clkin) begin
           reg_data_outr <= base_regs[base_addr];
       endcase
     end else if (flash_enable) begin
+      // CSR ready = $80, busy = $00 (bit7); the game polls this after a $D0 and waits
+      // while erase_busy so the MCU can fill the block before the next erase.
       casex (flash_addr)
         16'b1111111100000xxx:
-          reg_data_outr <= flash_status_r ? 8'h80 : flash_vendor_data[flash_addr&16'h0007];
+          reg_data_outr <= flash_status_r ? (erase_busy ? 8'h00 : 8'h80) : flash_vendor_data[flash_addr&16'h0007];
         16'b1111111100001xxx,
         16'b11111111000100xx:
-          reg_data_outr <= flash_status_r ? 8'h80 : 8'h00;
+          reg_data_outr <= flash_status_r ? (erase_busy ? 8'h00 : 8'h80) : 8'h00;
         default:
-          reg_data_outr <= 8'h80;
+          reg_data_outr <= (erase_busy ? 8'h00 : 8'h80);
       endcase
     end
   end else if(pgm_we_rising) begin
@@ -327,24 +352,43 @@ always @(posedge clkin) begin
     endcase
   end else if(reg_we_rising && flash_enable && (regs_outr[4'hc] | bs_slot)) begin
     if(flash_we_r) begin
-      flash_we_r <= 0;  // data phase after $10: program byte, not a command
-    end else if(bs_hirom ? ((snes_addr[23:16] == 8'he0) && (flash_addr[14:0] == 15'h0000))
-                : bs_slot ? ((snes_addr[23:16] == 8'hc0) && (flash_addr[14:0] == 15'h0000))
-                : (flash_addr == 16'h0000)) begin
-      // command port: base $C0:0000 exact, LoROM slot $C0:0000/8000, HiROM slot $E0:0000
-      flash_cmd0 <= reg_data_in;
-      if(flash_cmd0 == 8'h72 && reg_data_in == 8'h75) begin
-        flash_ovr_r <= 1;
-        flash_status_r <= 0;
-      end else if(reg_data_in == 8'hff) begin
-        flash_ovr_r <= 0;
-      end else if(reg_data_in[7:1] == 7'b0111000 || (flash_cmd0 == 8'h38 && reg_data_in == 8'hd0)) begin
-        flash_ovr_r <= 1;
-        flash_status_r <= 1;
-      end else if(reg_data_in == 8'h10) begin
-        flash_ovr_r <= 1;
-        flash_status_r <= 1;
-        flash_we_r <= 1;
+      flash_we_r <= 0;  // this write is the program byte, not a command
+    end else begin
+      // program/erase are issued at the target/block address (tracked here regardless
+      // of address); program only arms the write byte and leaves the read mode alone.
+      case(reg_data_in)
+        8'h10, 8'h40: begin flash_we_r <= 1'b1; erase_setup_r <= 1'b0; erase_all_setup_r <= 1'b0; end
+        8'h20: begin erase_setup_r <= 1'b1; erase_all_setup_r <= 1'b0; end
+        8'ha7: begin erase_all_setup_r <= 1'b1; erase_setup_r <= 1'b0; end
+        8'hd0: begin
+          // block = the $D0 (confirm) address, not $20 (setup): $20 is at the command
+          // port, $D0 at the block address ($C4:8000 -> block 2).
+          if(erase_setup_r) begin
+            bs_erase_seq_r <= bs_erase_seq_r + 1'b1; bs_erase_blk_r <= erase_blk_of_addr;
+            erase_busy_cnt <= {25{1'b1}};
+            flash_ovr_r <= 1'b1; flash_status_r <= 1'b1;
+          end else if(erase_all_setup_r) begin
+            bs_erase_seq_r <= bs_erase_seq_r + 1'b1; bs_erase_blk_r <= 4'hf;
+            erase_busy_cnt <= {25{1'b1}};
+            flash_ovr_r <= 1'b1; flash_status_r <= 1'b1;
+          end
+          erase_setup_r <= 1'b0; erase_all_setup_r <= 1'b0;
+        end
+        default: begin erase_setup_r <= 1'b0; erase_all_setup_r <= 1'b0; end
+      endcase
+      // mode commands ($FF/$70/$72/$75) only at the command port, so a stray pack
+      // write can't flip the read mode (HiROM $E0:0000 / LoROM $C0:0000)
+      if(bs_hirom ? ((snes_addr[23:16] == 8'he0) && (flash_addr[14:0] == 15'h0000))
+         : bs_slot ? ((snes_addr[23:16] == 8'hc0) && (flash_addr[14:0] == 15'h0000))
+         : (flash_addr == 16'h0000)) begin
+        flash_cmd0 <= reg_data_in;
+        if(flash_cmd0 == 8'h72 && reg_data_in == 8'h75) begin
+          flash_ovr_r <= 1'b1; flash_status_r <= 1'b0;
+        end else if(reg_data_in == 8'hff) begin
+          flash_ovr_r <= 1'b0;
+        end else if(reg_data_in[7:1] == 7'b0111000 || (flash_cmd0 == 8'h38 && reg_data_in == 8'hd0)) begin
+          flash_ovr_r <= 1'b1; flash_status_r <= 1'b1;
+        end
       end
     end
   end

--- a/verilog/sd2snes_base/main.v
+++ b/verilog/sd2snes_base/main.v
@@ -581,8 +581,13 @@ bsx snes_bsx(
   .bs_page_out(bs_page), // support only page 0000-03ff
   .bs_page_enable(bs_page_enable),
   .bs_page_offset(bs_page_offset),
-  .feat_bs_base_enable(feat_bs_base_enable)
+  .feat_bs_base_enable(feat_bs_base_enable),
+  .bs_erase_seq(bs_erase_seq),
+  .bs_erase_blk(bs_erase_blk)
 );
+// BS Memory Pack flash-erase request -> exposed in the MCU status word (mcu_cmd)
+wire [1:0] bs_erase_seq;
+wire [3:0] bs_erase_blk;
 
 spi snes_spi(
   .clk(CLK2),
@@ -645,6 +650,8 @@ mcu_cmd snes_mcu_cmd(
   .dac_ptr_out(dac_ptr_addr),
   .msu_addr_out(msu_write_addr),
   .MSU_STATUS(msu_status_out),
+  .bs_erase_seq(bs_erase_seq),
+  .bs_erase_blk(bs_erase_blk),
   .msu_status_reset_out(msu_status_reset_bits),
   .msu_status_set_out(msu_status_set_bits),
   .msu_status_reset_we(msu_status_reset_we),
@@ -949,7 +956,7 @@ assign ROM_OE = 1'b0;
 reg[17:0] SNES_DEAD_CNTr;
 initial SNES_DEAD_CNTr = 0;
 
-// context engine request
+// context engine request -- also reused for the BS flash program write.
 always @(posedge CLK2) begin
   if(CTX_WRQ) begin
     CTX_WR_PENDr <= 1'b1;
@@ -957,7 +964,15 @@ always @(posedge CLK2) begin
     CTX_ROM_ADDRr <= CTX_ADDR;
     CTX_ROM_DATAr <= CTX_DOUT;
     CTX_ROM_WORDr <= CTX_WORD;
-  end 
+  end
+  // BS flash program byte: the live SNES byte is valid at WR_end.  Skip $FF (flash AND
+  // makes it a no-op, so it preserves the byte the game wrote earlier, e.g. the name).
+  else if(SNES_WR_end & IS_FLASHWR & (SNES_DATA != 8'hff) & ~CTX_WR_PENDr) begin
+    CTX_WR_PENDr <= 1'b1;
+    CTX_ROM_ADDRr <= MAPPED_SNES_ADDR;
+    CTX_ROM_DATAr <= {SNES_DATA, SNES_DATA};
+    CTX_ROM_WORDr <= 1'b0; // byte write
+  end
   else if(STATE & ST_CTX_WR_END) begin
     CTX_WR_PENDr <= 1'b0;
     RQ_CTX_RDYr <= 1'b1;
@@ -1179,7 +1194,8 @@ assign ROM_WE = SD_DMA_TO_ROM
                 ? MCU_WRITE
                 : CTX_WE_HIT ? 1'b0
                 : DMA_WE_HIT ? 1'b0
-                : (ROM_HIT & ~loop_enable & (IS_WRITABLE | IS_FLASHWR) & SNES_CPU_CLK) ? SNES_WRITE
+                // flash program writes (IS_FLASHWR) are done by the CTX path above, not here
+                : (ROM_HIT & ~loop_enable & IS_WRITABLE & SNES_CPU_CLK) ? SNES_WRITE
                 : MCU_WE_HIT ? 1'b0
                 : 1'b1;
 

--- a/verilog/sd2snes_base/main.v
+++ b/verilog/sd2snes_base/main.v
@@ -146,6 +146,7 @@ wire [7:0] SRTC_SNES_DATA_OUT;
 wire [15:0] featurebits;
 wire feat_cmd_unlock = featurebits[5];
 wire feat_bs_base_enable = featurebits[12];
+wire feat_bs_slot = featurebits[14];
 
 wire r213f_enable;
 
@@ -561,6 +562,9 @@ dma snes_dma (
 bsx snes_bsx(
   .clkin(CLK2),
   .use_bsx(use_bsx),
+  .bs_slot(feat_bs_slot),
+  .bs_hirom(feat_bs_slot & (MAPPER == 3'b000)), // HiROM slot -> $E0-$EF
+
   .pgm_we(bsx_regs_reset_we),
   .snes_addr_in(SNES_ADDR),
   .reg_data_in(BSX_SNES_DATA_IN),

--- a/verilog/sd2snes_base/main.v
+++ b/verilog/sd2snes_base/main.v
@@ -559,6 +559,9 @@ dma snes_dma (
   .ROM_WORD_ENABLE(DMA_WORD)
 );
 
+// BS Memory Pack flash-erase request -> exposed in the MCU status word (mcu_cmd)
+wire [1:0] bs_erase_seq;
+wire [3:0] bs_erase_blk;
 bsx snes_bsx(
   .clkin(CLK2),
   .use_bsx(use_bsx),
@@ -585,9 +588,6 @@ bsx snes_bsx(
   .bs_erase_seq(bs_erase_seq),
   .bs_erase_blk(bs_erase_blk)
 );
-// BS Memory Pack flash-erase request -> exposed in the MCU status word (mcu_cmd)
-wire [1:0] bs_erase_seq;
-wire [3:0] bs_erase_blk;
 
 spi snes_spi(
   .clk(CLK2),

--- a/verilog/sd2snes_base/mcu_cmd.v
+++ b/verilog/sd2snes_base/mcu_cmd.v
@@ -64,6 +64,9 @@ module mcu_cmd(
   // MSU data
   output [13:0] msu_addr_out,
   input [7:0] MSU_STATUS,
+  // BS Memory Pack flash-erase request (surfaced in the GETSTATUS word)
+  input [1:0] bs_erase_seq,
+  input [3:0] bs_erase_blk,
   output [5:0] msu_status_reset_out,
   output [5:0] msu_status_set_out,
   output msu_status_reset_we,
@@ -170,10 +173,14 @@ wire mcu_nextaddr;
 reg DAC_STATUSr;
 reg SD_DMA_STATUSr;
 reg [7:0] MSU_STATUSr;
+reg [1:0] bs_erase_seqr;
+reg [3:0] bs_erase_blkr;
 always @(posedge clk) begin
   DAC_STATUSr <= DAC_STATUS;
   SD_DMA_STATUSr <= SD_DMA_STATUS;
   MSU_STATUSr <= MSU_STATUS;
+  bs_erase_seqr <= bs_erase_seq;
+  bs_erase_blkr <= bs_erase_blk;
 end
 
 reg SD_DMA_PARTIALr;
@@ -475,10 +482,10 @@ always @(posedge clk) begin
       MCU_DATA_IN_BUF <= 8'hA5;
     else if (cmd_data[7:0] == 8'hF1)
       case (spi_byte_cnt[0])
-        1'b1: // buffer status (1st byte)
-          MCU_DATA_IN_BUF <= {SD_DMA_STATUSr, DAC_STATUSr, MSU_STATUSr[7], 5'b0};
-        1'b0: // control status (2nd byte)
-          MCU_DATA_IN_BUF <= {1'b0, MSU_STATUSr[6:0]};
+        1'b1: // buffer status (1st byte): bits4-3 = erase seq, bits2-0 = block[2:0]
+          MCU_DATA_IN_BUF <= {SD_DMA_STATUSr, DAC_STATUSr, MSU_STATUSr[7], bs_erase_seqr, bs_erase_blkr[2:0]};
+        1'b0: // control status (2nd byte): bit7 = erase block[3]
+          MCU_DATA_IN_BUF <= {bs_erase_blkr[3], MSU_STATUSr[6:0]};
       endcase
     else if (cmd_data[7:0] == 8'hF2)
       case (spi_byte_cnt)

--- a/verilog/sd2snes_sa1/address.v
+++ b/verilog/sd2snes_sa1/address.v
@@ -45,7 +45,17 @@ module address(
   output branch1_enable,
   output branch2_enable,
   output branch3_enable,
-  output sa1_enable
+  output sa1_enable,
+  // BS Memory Pack flash slot (writable): write strobe + data in; write-enable
+  // and read-override (vendor "M P"/status) out.
+  input SNES_WR_end,
+  input [7:0] SNES_DATA_IN,
+  output IS_FLASHWR,
+  output BS_FLASH_OVR,
+  output [7:0] BS_FLASH_DOUT,
+  // Flash block-erase request to the MCU (seq increments per erase; blk 0xF = all)
+  output [1:0] bs_erase_seq,
+  output [3:0] bs_erase_blk
 );
 
 parameter [2:0]
@@ -56,6 +66,8 @@ parameter [2:0]
   FEAT_213F = 4,
   FEAT_2100 = 6
  ;
+// BS Memory Pack slot bit (>2:0, declared separately).  Mirrors sd2snes_base.
+localparam FEAT_BSSLOT = 14;
 
 // Static Inputs
 reg [23:0] ROM_MASK_r     = 0;
@@ -101,12 +113,129 @@ assign IS_SAVERAM = SAVERAM_MASK_r[0]
 
 assign IS_WRITABLE = IS_SAVERAM;
 
+// ROM address before the BS-pack redirect / ROM_MASK.  SA-1 SuperMMC: $C0-$FF use
+// xxb[bank]; $00-3F/$80-BF use the default {A23,A21} block unless xxb_en selects one.
+// Bits [22:20] = resolved MMC block (0..7), bits [19:0] = offset within the 1MB block.
+wire [23:0] ROM_ADDR_pre = (SNES_ADDR[22]
+                            ? {1'b0, xxb[SNES_ADDR[21:20]], SNES_ADDR[19:0]}
+                            : {1'b0, (xxb_en[{SNES_ADDR[23],SNES_ADDR[21]}] ? xxb[{SNES_ADDR[23],SNES_ADDR[21]}] : {1'b0,SNES_ADDR[23],SNES_ADDR[21]}), SNES_ADDR[20:16], SNES_ADDR[14:0]});
+
+// BS Memory Pack slot: when a pack is present (FEAT_BSSLOT) and the game points an MMC
+// bank register at block >= 4 (e.g. SD Gundam G Next: $2223=$84 after padding the cart
+// to 4MB, then reading the pack appended at the end), redirect those reads to the pack
+// staged at PSRAM 0x900000 (1MB, mirrored across blocks 4-7).  ROM_ADDR_pre[22] = high
+// bit of the 3-bit MMC block = "block >= 4".
+wire BS_PACK_HIT = featurebits[FEAT_BSSLOT] & ROM_ADDR_pre[22];
+
+`ifndef MK2
+// --- BS Memory Pack flash command FSM (writable slot) ----------------------
+// Like sd2snes_base/bsx.v, but keyed on the resolved pack offset so it follows
+// the SuperMMC.  Command port = pack offset 0.  Idle for ROM packs (G Next).
+// Gated out on mk2: SA-1 packs are read-only (read via SuperMMC, never flash
+// commands), so this whole FSM is dead there -- drop it to fit the Spartan-3.
+reg bs_flash_ovr_r = 1'b0;     // 1 = vendor/status override active (not read-array)
+reg bs_flash_status_r = 1'b0;  // 1 = status mode ($80); 0 = vendor mode ("M P")
+reg bs_flash_we_r = 1'b0;      // armed: the next pack write is the program data byte
+reg [7:0] bs_flash_cmd0 = 8'h00;
+
+// block erase = $20/$A7 then $D0 at the block address: seq counter the MCU compares,
+// busy timer so the game waits per block.
+reg [1:0] bs_erase_seq_r = 0;
+reg [3:0] bs_erase_blk_r = 0;
+reg bs_erase_setup_r = 0, bs_erase_all_setup_r = 0;
+reg [24:0] bs_erase_busy_cnt = 0;
+wire bs_erase_busy = (bs_erase_busy_cnt != 0);
+assign bs_erase_seq = bs_erase_seq_r;
+assign bs_erase_blk = bs_erase_blk_r;
+wire [3:0] bs_erase_blk_of = ROM_ADDR_pre[19:16]; // 64KB block within the 1MB pack
+
+wire bs_cmd_port = BS_PACK_HIT & (ROM_ADDR_pre[19:0] == 20'h00000); // pack offset 0
+wire [15:0] bs_flash_addr = ROM_ADDR_pre[15:0];
+
+always @(posedge CLK) begin
+  if(bs_erase_busy_cnt != 0) bs_erase_busy_cnt <= bs_erase_busy_cnt - 1'b1;  // WSM busy timer
+  if(SNES_WR_end & BS_PACK_HIT) begin
+    if(bs_flash_we_r) begin
+      bs_flash_we_r <= 1'b0;         // this write is the program byte, not a command
+    end else begin
+      // program/erase are issued at the target/block address (tracked regardless of
+      // address); program only arms the write byte.  Mode commands stay at the command port.
+      case(SNES_DATA_IN)
+        8'h10, 8'h40: begin bs_flash_we_r <= 1'b1; bs_erase_setup_r <= 1'b0; bs_erase_all_setup_r <= 1'b0; end
+        8'h20: begin bs_erase_setup_r <= 1'b1; bs_erase_all_setup_r <= 1'b0; end
+        8'ha7: begin bs_erase_all_setup_r <= 1'b1; bs_erase_setup_r <= 1'b0; end
+        8'hd0: begin
+          // block = the $D0 (confirm) address, not $20 (setup): $20 at the command port,
+          // $D0 at the block address.
+          if(bs_erase_setup_r) begin
+            bs_erase_seq_r <= bs_erase_seq_r + 1'b1; bs_erase_blk_r <= bs_erase_blk_of;
+            bs_erase_busy_cnt <= {25{1'b1}}; bs_flash_ovr_r <= 1'b1; bs_flash_status_r <= 1'b1;
+          end else if(bs_erase_all_setup_r) begin
+            bs_erase_seq_r <= bs_erase_seq_r + 1'b1; bs_erase_blk_r <= 4'hf;
+            bs_erase_busy_cnt <= {25{1'b1}}; bs_flash_ovr_r <= 1'b1; bs_flash_status_r <= 1'b1;
+          end
+          bs_erase_setup_r <= 1'b0; bs_erase_all_setup_r <= 1'b0;
+        end
+        default: begin bs_erase_setup_r <= 1'b0; bs_erase_all_setup_r <= 1'b0; end
+      endcase
+      if(bs_cmd_port) begin
+        bs_flash_cmd0 <= SNES_DATA_IN;
+        if(bs_flash_cmd0 == 8'h72 && SNES_DATA_IN == 8'h75) begin
+          bs_flash_ovr_r <= 1'b1; bs_flash_status_r <= 1'b0;          // vendor/page read
+        end else if(SNES_DATA_IN == 8'hff) begin
+          bs_flash_ovr_r <= 1'b0;                                     // read array
+        end else if(SNES_DATA_IN[7:1] == 7'b0111000                  // $70/$71 read status
+                    || (bs_flash_cmd0 == 8'h38 && SNES_DATA_IN == 8'hd0)) begin
+          bs_flash_ovr_r <= 1'b1; bs_flash_status_r <= 1'b1;
+        end
+      end
+    end
+  end
+end
+
+// program data-phase: enable the PSRAM write for the pack (consumed by main.v ROM_WE).
+// The command byte itself never reaches the array: bs_flash_we_r is still 0 while the
+// $10/$40 is written, and only flips on its trailing SNES_WR_end.
+assign IS_FLASHWR = BS_PACK_HIT & bs_flash_we_r;
+
+// read override: synth "M P" + chip info (vendor) or $80 (ready) in command modes.
+assign BS_FLASH_OVR = BS_PACK_HIT & bs_flash_ovr_r;
+reg [7:0] bs_flash_dout_r;
+always @(*) begin
+  casex(bs_flash_addr)
+    16'b1111111100000xxx:           // $FF00-$FF07: "4D 00 50 00 00 00 1A 00"
+      case(bs_flash_addr[2:0])
+        3'h0:    bs_flash_dout_r = bs_flash_status_r ? (bs_erase_busy ? 8'h00 : 8'h80) : 8'h4d; // 'M'
+        3'h2:    bs_flash_dout_r = bs_flash_status_r ? (bs_erase_busy ? 8'h00 : 8'h80) : 8'h50; // 'P'
+        3'h6:    bs_flash_dout_r = bs_flash_status_r ? (bs_erase_busy ? 8'h00 : 8'h80) : 8'h1a; // type1/1MB
+        default: bs_flash_dout_r = bs_flash_status_r ? (bs_erase_busy ? 8'h00 : 8'h80) : 8'h00;
+      endcase
+    16'b1111111100001xxx,
+    16'b11111111000100xx:           // $FF08-$FF13
+      bs_flash_dout_r = bs_flash_status_r ? (bs_erase_busy ? 8'h00 : 8'h80) : 8'h00;
+    default:
+      bs_flash_dout_r = (bs_erase_busy ? 8'h00 : 8'h80);  // CSR busy/ready
+  endcase
+end
+assign BS_FLASH_DOUT = bs_flash_dout_r;
+`else
+// mk2: flash FSM gated out -- tie the outputs off (pack still reads via SuperMMC below).
+assign IS_FLASHWR   = 1'b0;
+assign BS_FLASH_OVR = 1'b0;
+assign BS_FLASH_DOUT = 8'h00;
+assign bs_erase_seq = 2'b00;
+assign bs_erase_blk = 4'h0;
+`endif
+
 // TODO: add programmable address map
 assign SRAM_SNES_ADDR = (IS_SAVERAM
                          // 40-4F:0000-FFFF or 00-3F/80-BF:6000-7FFF (first 8K mirror).  Mask handles mirroring.  60 is sa1-only
                          ? (24'hE00000 + (iram_battery_r ? SNES_ADDR[10:0] : ((SNES_ADDR[22] ? SNES_ADDR[19:0] : {sa1_bmaps_sbm,SNES_ADDR[12:0]}) & SAVERAM_MASK_r)))
+                         // BS pack: MMC block >= 4 -> pack at PSRAM 0x900000 (no ROM_MASK)
+                         : BS_PACK_HIT
+                         ? (24'h900000 + {4'h0, ROM_ADDR_pre[19:0]})
                          // C0-FF:0000-FFFF or 00-3F/80-BF:8000-FFFF
-                         : ((SNES_ADDR[22] ? {1'b0, xxb[SNES_ADDR[21:20]], SNES_ADDR[19:0]} : {1'b0, (xxb_en[{SNES_ADDR[23],SNES_ADDR[21]}] ? xxb[{SNES_ADDR[23],SNES_ADDR[21]}] : {1'b0,SNES_ADDR[23],SNES_ADDR[21]}), SNES_ADDR[20:16], SNES_ADDR[14:0]}) & ROM_MASK_r)
+                         : (ROM_ADDR_pre & ROM_MASK_r)
                          );
 
 assign ROM_ADDR = SRAM_SNES_ADDR;

--- a/verilog/sd2snes_sa1/main.v
+++ b/verilog/sd2snes_sa1/main.v
@@ -445,7 +445,8 @@ sa1 snes_sa1 (
   .IRQ(SA1_IRQ),
   
   .SPEED(dsp_feat[0]),
-  
+  .bs_slot_en(featurebits[14]),   // BS Memory Pack slot: SA-1-side reads of block>=4 -> pack
+
   // State debug read interface
   .PGM_ADDR(SA1_PGM_ADDR), // [11:0]
   .PGM_DATA(SA1_PGM_DATA), // [7:0]
@@ -470,6 +471,9 @@ wire [31:0] cheat_pgm_data;
 wire [7:0] cheat_data_out;
 wire [2:0] cheat_pgm_idx;
 
+// BS Memory Pack flash-erase request -> exposed in the MCU status word (mcu_cmd)
+wire [1:0] bs_erase_seq;
+wire [3:0] bs_erase_blk;
 mcu_cmd snes_mcu_cmd(
   .clk(CLK2),
   .snes_sysclk(SNES_SYSCLK),
@@ -507,6 +511,8 @@ mcu_cmd snes_mcu_cmd(
   .dac_ptr_out(dac_ptr_addr),
   .msu_addr_out(msu_write_addr),
   .MSU_STATUS(msu_status_out),
+  .bs_erase_seq(bs_erase_seq),
+  .bs_erase_blk(bs_erase_blk),
   .msu_status_reset_out(msu_status_reset_bits),
   .msu_status_set_out(msu_status_set_bits),
   .msu_status_reset_we(msu_status_reset_we),
@@ -542,6 +548,11 @@ mcu_cmd snes_mcu_cmd(
   .dsp_feat_out(dsp_feat)
 );
 
+// BS Memory Pack flash slot (writable)
+wire IS_FLASHWR;
+wire bs_flash_ovr;
+wire [7:0] bs_flash_dout;
+
 address snes_addr(
   .CLK(CLK2),
   .MAPPER(MAPPER),
@@ -570,7 +581,15 @@ address snes_addr(
   .return_vector_enable(return_vector_enable),
   .branch1_enable(branch1_enable),
   .branch2_enable(branch2_enable),
-  .branch3_enable(branch3_enable)
+  .branch3_enable(branch3_enable),
+  // BS Memory Pack flash slot (writable)
+  .SNES_WR_end(SNES_WR_end),
+  .SNES_DATA_IN(SNES_DATA_IN),
+  .IS_FLASHWR(IS_FLASHWR),
+  .BS_FLASH_OVR(bs_flash_ovr),
+  .BS_FLASH_DOUT(bs_flash_dout),
+  .bs_erase_seq(bs_erase_seq),
+  .bs_erase_blk(bs_erase_blk)
 );
 
 reg pad_latch = 0;
@@ -670,6 +689,7 @@ assign SNES_DATA = (r213f_enable & ~SNES_PARD & ~r213f_forceread) ? r213fr
                                   : (ROM_HIT & IS_SAVERAM) ? RAM_DATA
                                   : (SA1_SCNT_NVSW & nmi_match) ? (SNES_ADDR[0] ? SA1_SNV[15:8] : SA1_SNV[7:0])
                                   : (SA1_SCNT_IVSW & irq_match) ? (SNES_ADDR[0] ? SA1_SIV[15:8] : SA1_SIV[7:0])
+                                  : bs_flash_ovr ? bs_flash_dout  // BS pack vendor/status override
                                   : (ROM_ADDR0 ? ROM_DATA[7:0] : ROM_DATA[15:8])
                                   ) : 8'bZ;
 
@@ -963,7 +983,7 @@ assign ROM_DATA[15:8] = ROM_ADDR0
 
 assign ROM_WE = SD_DMA_TO_ROM
                 ?MCU_WRITE
-                : (ROM_HIT & IS_WRITABLE
+                : (ROM_HIT & (IS_WRITABLE | IS_FLASHWR)  // IS_FLASHWR: BS pack program data-phase
                   & ~IS_SAVERAM
                   & SNES_CPU_CLK) ? SNES_WRITE
                 : MCU_WE_HIT ? 1'b0

--- a/verilog/sd2snes_sa1/mcu_cmd.v
+++ b/verilog/sd2snes_sa1/mcu_cmd.v
@@ -63,6 +63,9 @@ module mcu_cmd(
   // MSU data
   output [13:0] msu_addr_out,
   input [7:0] MSU_STATUS,
+  // BS Memory Pack flash-erase request (surfaced in the GETSTATUS word)
+  input [1:0] bs_erase_seq,
+  input [3:0] bs_erase_blk,
   output [5:0] msu_status_reset_out,
   output [5:0] msu_status_set_out,
   output msu_status_reset_we,
@@ -166,10 +169,14 @@ reg [7:0] feat_tmp;
 reg DAC_STATUSr;
 reg SD_DMA_STATUSr;
 reg [7:0] MSU_STATUSr;
+reg [1:0] bs_erase_seqr;
+reg [3:0] bs_erase_blkr;
 always @(posedge clk) begin
   DAC_STATUSr <= DAC_STATUS;
   SD_DMA_STATUSr <= SD_DMA_STATUS;
   MSU_STATUSr <= MSU_STATUS;
+  bs_erase_seqr <= bs_erase_seq;
+  bs_erase_blkr <= bs_erase_blk;
 end
 
 reg SD_DMA_PARTIALr;
@@ -449,10 +456,10 @@ always @(posedge clk) begin
       MCU_DATA_IN_BUF <= 8'hA5;
     else if (cmd_data[7:0] == 8'hF1)
       case (spi_byte_cnt[0])
-        1'b1: // buffer status (1st byte)
-          MCU_DATA_IN_BUF <= {SD_DMA_STATUSr, DAC_STATUSr, MSU_STATUSr[7], 5'b0};
-        1'b0: // control status (2nd byte)
-          MCU_DATA_IN_BUF <= {1'b0, MSU_STATUSr[6:0]};
+        1'b1: // buffer status (1st byte): bits4-3 = erase seq, bits2-0 = block[2:0]
+          MCU_DATA_IN_BUF <= {SD_DMA_STATUSr, DAC_STATUSr, MSU_STATUSr[7], bs_erase_seqr, bs_erase_blkr[2:0]};
+        1'b0: // control status (2nd byte): bit7 = erase block[3]
+          MCU_DATA_IN_BUF <= {bs_erase_blkr[3], MSU_STATUSr[6:0]};
       endcase
     else if (cmd_data[7:0] == 8'hF2)
       case (spi_byte_cnt)

--- a/verilog/sd2snes_sa1/sa1.v
+++ b/verilog/sd2snes_sa1/sa1.v
@@ -76,6 +76,10 @@ module sa1(
 
   input         SPEED,
 
+  // BS Memory Pack slot present (FEAT_BSSLOT): redirect SA-1-side ROM reads of
+  // MMC block >= 4 to the pack (same as the S-CPU path in address.v).
+  input         bs_slot_en,
+
   // State debug read interface
   input  [11:0] PGM_ADDR, // [11:0]
   output [7:0]  PGM_DATA, // [7:0]
@@ -219,7 +223,14 @@ wire [3:0] xxb_en;
 `define IS_MMIO(a) (~a[22] & ~a[15] & ~a[14] & a[13] & ~a[12] & ~a[11] & ~a[10] & a[9])          // 00-3F/80-BF:2200-23FF
 `define IS_SA1_PRAM(a) ((sw46 & ~a[22] & ~a[15] & &a[14:13]) | (~a[23] & a[22] & a[21] & ~a[20])) // 00-3F/80-BF:6000-7FFF, 60-6F:0000-FFFF
 
-`define MAP_ROM(a)  ((a[22] ? {1'b0, xxb[a[21:20]], a[19:0]} : {1'b0, xxb_en[{a[23],a[21]}] ? xxb[{a[23],a[21]}] : {1'b0,a[23],a[21]}, a[20:16], a[14:0]}) & ROM_MASK_r)
+// Raw SA-1 ROM map (SuperMMC): block in bits [22:20], offset [19:0], then ROM_MASK.
+`define MAP_ROM_RAW(a)  ((a[22] ? {1'b0, xxb[a[21:20]], a[19:0]} : {1'b0, xxb_en[{a[23],a[21]}] ? xxb[{a[23],a[21]}] : {1'b0,a[23],a[21]}, a[20:16], a[14:0]}) & ROM_MASK_r)
+// BS Memory Pack redirect (parity with address.v): when a pack is present and the
+// resolved MMC block is >= 4, read the pack at PSRAM 0x900000 instead of the cart.
+// ">= 4" (not [2]) avoids a bit-select on an array element (Verilog-2001).
+`define MAP_BLKHI(a)    (a[22] ? (xxb[a[21:20]] >= 3'd4) : (xxb_en[{a[23],a[21]}] & (xxb[{a[23],a[21]}] >= 3'd4)))
+`define MAP_OFF(a)      (a[22] ? a[19:0] : {a[20:16], a[14:0]})
+`define MAP_ROM(a)      ((bs_slot_en & `MAP_BLKHI(a)) ? (24'h900000 + {4'h0, `MAP_OFF(a)}) : `MAP_ROM_RAW(a))
 `define MAP_IRAM(a) (a[10:0])
 `define MAP_MMIO(a) (a[8:0])
 //`define MAP_BRAM(a) (iram_battery_r ? `MAP_IRAM(a) : ((a[22] ? a[19:0] : {cbm[4:0],a[12:0]}) & SAVERAM_MASK_r))


### PR DESCRIPTION
Hello!

This PR add support to 8M Memory Pack slot carts and enable Derby Stallion 96 and Sound Novel Tsukuru

Only the SA-1 carts are left out of memory pack support at the moment.

The currently already working slotted games area checked during boot for the presense of a pack (.mpk file, just .bs renamed to .mpk inside /sd2snes/saves/) and if found, the game is scanned for the vendor probe to detect if it's a real slotted cart. If so, the pack is loaded into PSRAM and mapped to the correct address range depending on the cart type (LoROM or HiROM). The pack is also flash memory, so it can be written to by the game, and these writes are saved back to the .mpk file on disk.

Derby Stallion 96 and Sound Novel Tsukuru are 3 MB LoROM carts with one odd thing: banks $80-$9F point at the top 1 MB
of the ROM (file $200000+) instead of mirroring $00-$1F so they can fit the pack window there.

<img width="300" src="https://github.com/user-attachments/assets/d2e6fb41-bcd3-40e9-b3a0-73b1f7345972" />
<img width="300" src="https://github.com/user-attachments/assets/be0f0ecc-2240-48b6-acc7-5aa886be0a7b" />
<img width="300" src="https://github.com/user-attachments/assets/944aad90-e990-4bfd-97d4-6b5c4f66461a" />

