### PR TITLE
FPGA CMD NMI Hook Status Bit

### DIFF
--- a/src/fpga_spi.h
+++ b/src/fpga_spi.h
@@ -56,6 +56,8 @@
 #define FEAT_ST0010        (1 << 1)
 #define FEAT_DSPX          (1 << 0)
 
+#define FPGA_STATUS_SNES_HOOK_ACTIVE (0x0100)
+
 #define FPGA_WAIT_RDY()    do {__NOP(); __NOP(); __NOP(); __NOP(); while(!BITBAND(SPI_REGS->SPI_SR, SPI_TFE)); __NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP();__NOP(); while(!BITBAND(FPGA_MCU_RDY_REG->GPIO_I, FPGA_MCU_RDY_BIT)); } while (0)
 
 /* command parameters */

--- a/src/usbinterface.c
+++ b/src/usbinterface.c
@@ -1029,14 +1029,14 @@ int usbint_handler_exe(void) {
         fpga_write_snescmd(0x00);
 
         // wait to make sure we are out of the code.
-        int tick = getticks();
+        int ticks = getticks();
         uint16_t prev_status = fpga_status();
         while (1) {
             uint16_t current_status = fpga_status();
 
             if (((prev_status & FPGA_STATUS_SNES_HOOK_ACTIVE) && 
             !(current_status & FPGA_STATUS_SNES_HOOK_ACTIVE)) ||
-            getticks() > ticks + 2) 
+            getticks() >= ticks + 2) 
             {
                 break;
             }

--- a/src/usbinterface.c
+++ b/src/usbinterface.c
@@ -1028,9 +1028,18 @@ int usbint_handler_exe(void) {
         fpga_set_snescmd_addr(SNESCMD_EXE);
         fpga_write_snescmd(0x00);
 
-        // wait to make sure we are out of the code.  one frame should do
-        // TODO: could check with the fpga for this
-        sleep_ms(16);
+        // wait to make sure we are out of the code.
+        uint16_t prev_status = fpga_status();
+        while (1) {
+            uint16_t current_status = fpga_status();
+
+            if ((prev_status & FPGA_STATUS_SNES_HOOK_ACTIVE) && 
+                !(current_status & FPGA_STATUS_SNES_HOOK_ACTIVE)) {
+                break;
+            }
+
+            prev_status = current_status;
+        }
 
         for (int i = 1; i < server_info.size; i++) {
             uint8_t val = sram_readbyte(server_info.offset + i);

--- a/src/usbinterface.c
+++ b/src/usbinterface.c
@@ -1029,12 +1029,15 @@ int usbint_handler_exe(void) {
         fpga_write_snescmd(0x00);
 
         // wait to make sure we are out of the code.
+        int tick = getticks();
         uint16_t prev_status = fpga_status();
         while (1) {
             uint16_t current_status = fpga_status();
 
-            if ((prev_status & FPGA_STATUS_SNES_HOOK_ACTIVE) && 
-                !(current_status & FPGA_STATUS_SNES_HOOK_ACTIVE)) {
+            if (((prev_status & FPGA_STATUS_SNES_HOOK_ACTIVE) && 
+            !(current_status & FPGA_STATUS_SNES_HOOK_ACTIVE)) ||
+            getticks() > ticks + 2) 
+            {
                 break;
             }
 

--- a/verilog/sd2snes_base/main.v
+++ b/verilog/sd2snes_base/main.v
@@ -673,7 +673,8 @@ mcu_cmd snes_mcu_cmd(
   .snescmd_data_in(snescmd_data_in_mcu),
   .cheat_pgm_idx_out(cheat_pgm_idx),
   .cheat_pgm_data_out(cheat_pgm_data),
-  .cheat_pgm_we_out(cheat_pgm_we)
+  .cheat_pgm_we_out(cheat_pgm_we),
+  .SNES_HOOK_ACTIVE(snescmd_unlock)
 );
 
 address snes_addr(

--- a/verilog/sd2snes_base/mcu_cmd.v
+++ b/verilog/sd2snes_base/mcu_cmd.v
@@ -108,7 +108,10 @@ module mcu_cmd(
   // cheat configuration
   output reg [7:0] cheat_pgm_idx_out,
   output reg [31:0] cheat_pgm_data_out,
-  output reg cheat_pgm_we_out
+  output reg cheat_pgm_we_out,
+
+  // NMI hook status
+  input SNES_HOOK_ACTIVE
 );
 
 initial begin
@@ -170,10 +173,12 @@ wire mcu_nextaddr;
 reg DAC_STATUSr;
 reg SD_DMA_STATUSr;
 reg [7:0] MSU_STATUSr;
+reg SNES_HOOK_ACTIVEr;
 always @(posedge clk) begin
   DAC_STATUSr <= DAC_STATUS;
   SD_DMA_STATUSr <= SD_DMA_STATUS;
   MSU_STATUSr <= MSU_STATUS;
+  SNES_HOOK_ACTIVEr <= SNES_HOOK_ACTIVE;
 end
 
 reg SD_DMA_PARTIALr;
@@ -476,7 +481,7 @@ always @(posedge clk) begin
     else if (cmd_data[7:0] == 8'hF1)
       case (spi_byte_cnt[0])
         1'b1: // buffer status (1st byte)
-          MCU_DATA_IN_BUF <= {SD_DMA_STATUSr, DAC_STATUSr, MSU_STATUSr[7], 5'b0};
+          MCU_DATA_IN_BUF <= {SD_DMA_STATUSr, DAC_STATUSr, MSU_STATUSr[7], 4'b0, SNES_HOOK_ACTIVEr};
         1'b0: // control status (2nd byte)
           MCU_DATA_IN_BUF <= {1'b0, MSU_STATUSr[6:0]};
       endcase

--- a/verilog/sd2snes_dsp/main.v
+++ b/verilog/sd2snes_dsp/main.v
@@ -640,7 +640,8 @@ mcu_cmd snes_mcu_cmd(
   .cheat_pgm_idx_out(cheat_pgm_idx),
   .cheat_pgm_data_out(cheat_pgm_data),
   .cheat_pgm_we_out(cheat_pgm_we),
-  .dsp_feat_out(dsp_feat)
+  .dsp_feat_out(dsp_feat),
+  .SNES_HOOK_ACTIVE(snescmd_unlock)
 );
 
 address snes_addr(

--- a/verilog/sd2snes_dsp/mcu_cmd.v
+++ b/verilog/sd2snes_dsp/mcu_cmd.v
@@ -110,7 +110,10 @@ module mcu_cmd(
   output reg cheat_pgm_we_out,
 
   // DSP core features
-  output reg [15:0] dsp_feat_out = 16'h0000
+  output reg [15:0] dsp_feat_out = 16'h0000,
+
+  // NMI hook status
+  input SNES_HOOK_ACTIVE
 );
 
 initial begin
@@ -165,10 +168,12 @@ wire mcu_nextaddr;
 reg DAC_STATUSr;
 reg SD_DMA_STATUSr;
 reg [7:0] MSU_STATUSr;
+reg SNES_HOOK_ACTIVEr;
 always @(posedge clk) begin
   DAC_STATUSr <= DAC_STATUS;
   SD_DMA_STATUSr <= SD_DMA_STATUS;
   MSU_STATUSr <= MSU_STATUS;
+  SNES_HOOK_ACTIVEr <= SNES_HOOK_ACTIVE;
 end
 
 reg SD_DMA_PARTIALr;
@@ -467,7 +472,7 @@ always @(posedge clk) begin
     else if (cmd_data[7:0] == 8'hF1)
       case (spi_byte_cnt[0])
         1'b1: // buffer status (1st byte)
-          MCU_DATA_IN_BUF <= {SD_DMA_STATUSr, DAC_STATUSr, MSU_STATUSr[7], 5'b0};
+          MCU_DATA_IN_BUF <= {SD_DMA_STATUSr, DAC_STATUSr, MSU_STATUSr[7], 4'b0, SNES_HOOK_ACTIVEr};
         1'b0: // control status (2nd byte)
           MCU_DATA_IN_BUF <= {1'b0, MSU_STATUSr[6:0]};
       endcase


### PR DESCRIPTION
This addresses a TODO in `usbinterface.c` when overwriting the NMI hook the MCU needs to wait for the SNES to not be executing the hook.