### PR TITLE
SuperFX 4/8/11MB memory map (work in progress)

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -436,7 +436,9 @@ uint32_t load_rom(uint8_t* filename, uint32_t base_addr, uint8_t flags) {
   set_rom_mask(rommask);
   readled(0);
 
-  printf("gsu=%x sa1=%x srambase=%lx sramsize=%lx\n", romprops.has_gsu, romprops.has_sa1, romprops.srambase, romprops.sramsize_bytes);
+  printf("gsu=%x sa1=%x mapper=%d srambase=%lx sramsize=%lx\n",
+         romprops.has_gsu, romprops.has_sa1, romprops.mapper_id,
+         romprops.srambase, romprops.sramsize_bytes);
   if(flags & LOADROM_WITH_SRAM) {
     if(romprops.ramsize_bytes) {
       // powerslide relies on the init value to be 00.

--- a/src/smc.c
+++ b/src/smc.c
@@ -205,7 +205,15 @@ void smc_id(snes_romprops_t* props, uint32_t file_offset) {
         props->has_gsu = 1;
         props->fpga_conf = FPGA_GSU;
         props->fpga_dspfeat = CFG.gsu_speed;
-        header->ramsize = header->expramsize & 0x7;
+        if(header->expramsize <= 10) {
+          header->ramsize = header->expramsize;
+        } else {
+          header->ramsize = 7;
+        }
+        if(header->romsize >= 0x0E) {
+          props->mapper_id = 5;
+          printf("SuperFX 11MB map enabled (romsize=%02x)\n", header->romsize);
+        }
       }
       break;
 
@@ -295,7 +303,8 @@ void smc_id(snes_romprops_t* props, uint32_t file_offset) {
     props->fpga_features |= FEAT_COMBO;
   }
   
-  if(header->romsize == 0 || header->romsize > 13) {
+  // allow 0x0E (16MB mask) for 11mb superfx
+  if(header->romsize == 0 || header->romsize > 14) {
     props->romsize_bytes = 1024;
     header->romsize = 0;
     if(file_handle.fsize >= 1024) {
@@ -308,6 +317,9 @@ void smc_id(snes_romprops_t* props, uint32_t file_offset) {
   props->ramsize_bytes = (uint32_t)1024 << header->ramsize;
   props->romsize_bytes = (uint32_t)1024 << header->romsize;
   props->expramsize_bytes = (uint32_t)1024 << header->expramsize;
+  if(props->has_gsu && header->romsize >= 0x0E) {
+    props->mapper_id = 5;
+  }
 /*dprintf("ramsize_bytes: %ld\n", props->ramsize_bytes); */
   if(props->ramsize_bytes < 2048) {
     props->ramsize_bytes = 0;

--- a/verilog/sd2snes_gsu/address.v
+++ b/verilog/sd2snes_gsu/address.v
@@ -52,31 +52,49 @@ parameter [2:0]
   FEAT_2100 = 6
 ;
 
+wire map_gsu_11mb = ROM_MASK[23] | (MAPPER == 3'b101);
+
 wire [23:0] SRAM_SNES_ADDR;
+
+wire is_gsu_ram_mirror = ~SNES_ADDR[22]
+                       & ~SNES_ADDR[15]
+                       & &SNES_ADDR[14:13];
+
+wire is_gsu_ram_classic = &SNES_ADDR[22:21]
+                        & ~SNES_ROMSEL;
+
+wire is_gsu_ram_11mb = ~SNES_ADDR[23]
+                     & &SNES_ADDR[22:20]
+                     & ~SNES_ROMSEL;
 
 assign IS_ROM = ~SNES_ROMSEL;
 
 assign IS_SAVERAM = SAVERAM_MASK[0]
-                    & ( // 60-7D/E0-FF:0000-FFFF
-                        ( &SNES_ADDR[22:21]
-                        & ~SNES_ROMSEL
-                        )
-                        // 00-3F/80-BF:6000-7FFF
-                      | ( ~SNES_ADDR[22]
-                        & ~SNES_ADDR[15]
-                        & &SNES_ADDR[14:13]
-                        )
+                    & ( is_gsu_ram_mirror
+                      | (map_gsu_11mb ? is_gsu_ram_11mb : is_gsu_ram_classic)
                       );
 
 assign IS_WRITABLE = IS_SAVERAM;
 
 // GSU has a weird hybrid of Lo and Hi ROM formats.
-// TODO: add programmable address map
+wire [23:0] rom_addr_classic =
+  (SNES_ADDR[22] ? {2'b00, SNES_ADDR[21:0]}
+                 : {2'b00, SNES_ADDR[22:16], SNES_ADDR[14:0]}) & ROM_MASK;
+
+wire [23:0] rom_addr_11mb_lorom =
+  {2'b00, SNES_ADDR[23], SNES_ADDR[21:16], SNES_ADDR[14:0]};
+
+wire [23:0] rom_addr_11mb_hi =
+  SNES_ADDR[23] ? {2'b01, SNES_ADDR[21:0]}
+                : {2'b10, SNES_ADDR[21:0]};
+
+wire [23:0] rom_addr_11mb =
+  (SNES_ADDR[22] ? rom_addr_11mb_hi : rom_addr_11mb_lorom) & ROM_MASK;
+
 assign SRAM_SNES_ADDR = (IS_SAVERAM
-                         // 60-7D/E0-FF:0000-FFFF or 00-3F/80-BF:6000-7FFF (first 8K mirror)
-                         ? (24'hE00000 + ((SNES_ADDR[22] ? SNES_ADDR[16:0] : SNES_ADDR[12:0]) & SAVERAM_MASK))
-                         // 40-5F/C0-DF:0000-FFFF or 00-3F/80-BF:8000-FFFF
-                         : ((SNES_ADDR[22] ? {2'b00, SNES_ADDR[21:0]} : {2'b00, SNES_ADDR[22:16], SNES_ADDR[14:0]}) & ROM_MASK)
+                         ? (24'hE00000 + ((SNES_ADDR[22] ? SNES_ADDR[19:0]
+                                                         : {7'b0, SNES_ADDR[12:0]}) & SAVERAM_MASK))
+                         : (map_gsu_11mb ? rom_addr_11mb : rom_addr_classic)
                          );
 
 assign ROM_ADDR = SRAM_SNES_ADDR;
@@ -92,7 +110,6 @@ assign return_vector_enable = (SNES_ADDR == 24'h002A6C);
 assign branch1_enable = (SNES_ADDR == 24'h002A1F);
 assign branch2_enable = (SNES_ADDR == 24'h002A59);
 assign branch3_enable = (SNES_ADDR == 24'h002A5E);
-// 00-3F/80-BF:3000-32FF gsu registers.  TODO: some emulators go to $34FF???
-assign gsu_enable = (!SNES_ADDR[22] && ({SNES_ADDR[15:10],2'h0} == 8'h30)) && (SNES_ADDR[9:8] != 2'h3);
+assign gsu_enable = (!SNES_ADDR[22] && (SNES_ADDR[15:8] >= 8'h30) && (SNES_ADDR[15:8] <= 8'h34));
 
 endmodule

--- a/verilog/sd2snes_gsu/gsu.v
+++ b/verilog/sd2snes_gsu/gsu.v
@@ -1582,7 +1582,7 @@ always @(posedge CLK) begin
         //cache_gsu_addr_r    <= (REG_r[R15][15:0] - CBR_r);
 
         // need to use PBR directly here because of prior cycle update
-        cache_addr_r <= (PBR_r < 8'h60) ? ((PBR_r[6] ? {PBR_r,REG_r[R15]} : {PBR_r,REG_r[R15][14:0]}) & ROM_MASK)
+        cache_addr_r <= (PBR_r < 8'h60) ? ((PBR_r[6] ? {PBR_r,REG_r[R15]} : {PBR_r,REG_r[R15][14:0]}) & ROM_MASK & 24'h1FFFFF)
                                         : 24'hE00000 + ({PBR_r[0],REG_r[R15]} & SAVERAM_MASK);
 
         FETCH_STATE <= ST_FETCH_CACHE;
@@ -1761,7 +1761,7 @@ always @(posedge CLK) begin
         prf_rom_rd_r <= 1;
         prf_word_r <= 0;
 
-        prf_addr_r <= ((ROMBR_r[6] ? {ROMBR_r,REG_r[R14]} : {ROMBR_r,REG_r[R14][14:0]}) & ROM_MASK);
+        prf_addr_r <= ((ROMBR_r[6] ? {ROMBR_r,REG_r[R14]} : {ROMBR_r,REG_r[R14][14:0]}) & ROM_MASK & 24'h1FFFFF);
 
         PRF_STATE <= ST_PRF_MEMORY_WAIT;
       end
@@ -2685,7 +2685,7 @@ always @(posedge CLK) begin
     brk_error        <= fetch_error; // FIXME: set this state based on opcode or other error condition
 
 
-    brk_addr_r <= (CONFIG_ADDR_WATCH[23:16] < 8'h60) ? ((CONFIG_ADDR_WATCH[22] ? CONFIG_ADDR_WATCH : {CONFIG_ADDR_WATCH[20:16],CONFIG_ADDR_WATCH[14:0]}) & ROM_MASK)
+    brk_addr_r <= (CONFIG_ADDR_WATCH[23:16] < 8'h60) ? ((CONFIG_ADDR_WATCH[22] ? CONFIG_ADDR_WATCH : {CONFIG_ADDR_WATCH[20:16],CONFIG_ADDR_WATCH[14:0]}) & ROM_MASK & 24'h1FFFFF)
                                                      : 24'hE00000 + (CONFIG_ADDR_WATCH & SAVERAM_MASK);
   end
 end


### PR DESCRIPTION
Solves #271 

Implements the following memory layout to the SuperFX by setting ROM 0x7FD7 (romsize) to 0x0e:

* $00-$3F $8000-$FFFF maps to the first 2MB of the rom (GSU can still only read this portion)
* $80-$BF $8000-$FFFF maps to the second 2MB of the rom
* $C0-$FF $0000-$FFFF maps to the third 4mb of ROM (hirom)
* $40-$6F $0000-$FFFF maps to the fourth 3mb of ROM (hirom)
* $70-$7D $0000-$FFFF maps to SRAM

Example ROM:

[rom.zip](https://github.com/user-attachments/files/30075468/rom.zip)

Haven't verified that this doesn't affect other games (though Star Fox and Star Fox 2 seemed to work fine) or worsens perfomance (I wanted to just dyplicate the GSU core for this to not affect the main one, but I thought that was kind of wasteful), but I think the checks are enough.