### PR TITLE
CX4 Accuracy Improvements

### DIFF
--- a/verilog/sd2snes_cx4/cx4.v
+++ b/verilog/sd2snes_cx4/cx4.v
@@ -160,15 +160,12 @@ reg [23:0] cpu_idb; // tmp register for reg file read
        OR selected cache page does not contain requested page already)
 */
 reg CACHE_TRIG_ENr;
-reg CACHE_TRIG_EN2r;
 reg cpu_cache_en;
 initial begin
   CACHE_TRIG_ENr = 1'b0;
-  CACHE_TRIG_EN2r = 1'b0;
   cpu_cache_en = 1'b0;
 end
-always @(posedge CLK) CACHE_TRIG_EN2r <= CACHE_TRIG_ENr;
-wire CACHE_TRIG_EN = CACHE_TRIG_EN2r;
+wire CACHE_TRIG_EN = CACHE_TRIG_ENr;
 
 reg DMA_TRIG_ENr;
 initial DMA_TRIG_ENr = 1'b0;

--- a/verilog/sd2snes_cx4/cx4.v
+++ b/verilog/sd2snes_cx4/cx4.v
@@ -154,11 +154,7 @@ wire GPR_WR_EN = gpr_enable & reg_we_rising;
 
 reg [23:0] cpu_idb; // tmp register for reg file read
 
-/* Need to cache when:
-   1f48 is written
-  AND (selected cache page is invalid
-       OR selected cache page does not contain requested page already)
-*/
+/* Need to cache when 1f48 is written */
 reg CACHE_TRIG_ENr;
 reg cpu_cache_en;
 initial begin
@@ -314,9 +310,7 @@ initial cache_count = 9'b0;
 always @(posedge CLK) begin
   case(CACHE_ST)
     ST_CACHE_IDLE: begin
-      if(CACHE_TRIG_EN
-         & (~cachevalid[cx4_mmio_cachepage]
-            | |(cachetag[cx4_mmio_cachepage] ^ cx4_mmio_pgmpage))) begin
+      if(CACHE_TRIG_EN) begin
         CACHE_ST <= ST_CACHE_START;
         cache_pgmpage <= cx4_mmio_pgmpage;
         cache_cachepage <= cx4_mmio_cachepage;

--- a/verilog/sd2snes_cx4/cx4.v
+++ b/verilog/sd2snes_cx4/cx4.v
@@ -186,6 +186,7 @@ reg [23:0] cpu_a;
 reg fl_n;
 reg fl_z;
 reg fl_c;
+reg condtrue;
 
 
 reg cpu_go_en_r;
@@ -316,8 +317,8 @@ always @(posedge CLK) begin
         cache_cachepage <= cx4_mmio_cachepage;
         cx4_busy[BUSY_CACHE] <= 1'b1;
       end else if(cpu_cache_en
-         & (~cachevalid[~cpu_page]
-            | |(cachetag[~cpu_page] ^ cpu_p))) begin
+         & (~cachevalid[~cpu_page] | |(cachetag[~cpu_page] ^ cpu_p))
+         & condtrue) begin
         CACHE_ST <= ST_CACHE_START;
         cache_pgmpage <= cpu_p;
         cache_cachepage <= ~cpu_page;
@@ -476,7 +477,6 @@ reg op_imm;
 reg op_p;
 reg op_call;
 reg op_jump;
-reg condtrue;
 reg mul_strobe = 0;
 
 always @(posedge CLK) begin

--- a/verilog/sd2snes_cx4/cx4.v
+++ b/verilog/sd2snes_cx4/cx4.v
@@ -496,6 +496,12 @@ end
 reg jp_docache;
 initial jp_docache = 1'b0;
 
+reg [1:0] cpu_wait_subcyc;
+initial cpu_wait_subcyc = 2'b00;
+
+reg op_jp_taken;
+reg op_skip_taken;
+
 always @(posedge CLK) begin
   mul_strobe <= 1'b0;
   case(CPU_STATE)
@@ -607,6 +613,7 @@ always @(posedge CLK) begin
       case(op)
         OP_JP: begin
           cpu_cache_en <= 1'b0;
+          op_jp_taken <= condtrue;
           if(!cpu_cache_en && !cx4_busy[BUSY_CACHE]) begin
             jp_docache <= 1'b0;
             if(condtrue) begin
@@ -621,6 +628,7 @@ always @(posedge CLK) begin
           end
         end
         OP_SKIP: begin
+          op_skip_taken <= condtrue;
           if(condtrue) cpu_pc <= cpu_pc + 2;
           else cpu_pc <= cpu_pc + 1;
         end
@@ -704,6 +712,7 @@ always @(posedge CLK) begin
       endcase
     end
     ST_CPU_3: begin
+      cpu_wait_subcyc <= 2'b00;
       case(op)
         OP_BUS: cpu_busaddr <= cpu_busaddr + 1;
         OP_WRRAM: cx4_cpu_datram_we <= 1'b0;
@@ -737,20 +746,20 @@ always @(posedge CLK) begin
 
       casex(cpu_op_w[15:11])
         5'b00100: begin // SKIP
-          cpu_wait <= 8'h01;
-          CPU_STATE <= speed ? ST_CPU_0 : ST_CPU_4;
+          cpu_wait <= op_skip_taken ? 8'h01 : 8'h00;
+          CPU_STATE <= (op_skip_taken && !speed) ? ST_CPU_4 : ST_CPU_0;
         end
         5'b00111: begin // RT
-          cpu_wait <= 8'h03;
+          cpu_wait <= 8'h02;
           CPU_STATE <= speed ? ST_CPU_0 : ST_CPU_4;
         end
         5'b00x01, 5'b00x10: begin // JP
           if(cpu_op_w[13]) begin // CALL
-            cpu_wait <= 8'h03;
+            cpu_wait <= op_jp_taken ? 8'h02 : 8'h00;
           end else begin
-            cpu_wait <= 8'h03;
+            cpu_wait <= op_jp_taken ? 8'h02 : 8'h00;
           end
-          CPU_STATE <= speed ? ST_CPU_0 : ST_CPU_4;
+          CPU_STATE <= (op_jp_taken && !speed) ? ST_CPU_4 : ST_CPU_0;
         end
 /*        5'b01110, 5'b01101, 5'b11101: begin // RDROM, RDRAM, WRRAM
           cpu_wait <= 8'h03;
@@ -814,9 +823,15 @@ always @(posedge CLK) begin
       op_sa <= cpu_op_w[9:8];
     end
     ST_CPU_4: begin
-      cpu_wait <= cpu_wait - 1;
-      if(cpu_wait) CPU_STATE <= ST_CPU_4;
-      else CPU_STATE <= ST_CPU_0;
+      if(cpu_wait_subcyc == 2'b11) begin
+        cpu_wait_subcyc <= 2'b00;
+        cpu_wait <= cpu_wait - 1;
+        if(cpu_wait == 8'h01) CPU_STATE <= ST_CPU_0;
+        else CPU_STATE <= ST_CPU_4;
+      end else begin
+        cpu_wait_subcyc <= cpu_wait_subcyc + 1;
+        CPU_STATE <= ST_CPU_4;
+      end
     end
   endcase
 end

--- a/verilog/sd2snes_cx4/cx4.v
+++ b/verilog/sd2snes_cx4/cx4.v
@@ -499,9 +499,6 @@ initial jp_docache = 1'b0;
 reg [1:0] cpu_wait_subcyc;
 initial cpu_wait_subcyc = 2'b00;
 
-reg op_jp_taken;
-reg op_skip_taken;
-
 always @(posedge CLK) begin
   mul_strobe <= 1'b0;
   case(CPU_STATE)
@@ -613,7 +610,6 @@ always @(posedge CLK) begin
       case(op)
         OP_JP: begin
           cpu_cache_en <= 1'b0;
-          op_jp_taken <= condtrue;
           if(!cpu_cache_en && !cx4_busy[BUSY_CACHE]) begin
             jp_docache <= 1'b0;
             if(condtrue) begin
@@ -624,18 +620,24 @@ always @(posedge CLK) begin
               end
               cpu_pc <= op_param;
               cpu_page <= cpu_page ^ op_p;
+              cpu_wait <= 8'h02;
+              CPU_STATE <= speed ? ST_CPU_2 : ST_CPU_4;
             end else cpu_pc <= cpu_pc + 1;
           end
         end
         OP_SKIP: begin
-          op_skip_taken <= condtrue;
-          if(condtrue) cpu_pc <= cpu_pc + 2;
-          else cpu_pc <= cpu_pc + 1;
+          if(condtrue) begin
+            cpu_pc <= cpu_pc + 2;
+            cpu_wait <= 8'h01;
+            CPU_STATE <= speed ? ST_CPU_2 : ST_CPU_4;
+          end else cpu_pc <= cpu_pc + 1;
         end
         OP_RT: begin
           cpu_page <= cpu_page_stack[cpu_sp - 1];
           cpu_pc <= cpu_pc_stack[cpu_sp - 1];
           cpu_sp <= cpu_sp - 1;
+          cpu_wait <= 8'h02;
+          CPU_STATE <= speed ? ST_CPU_2 : ST_CPU_4;
         end
         OP_WAI: if(BUS_RDY) cpu_pc <= cpu_pc + 1;
         OP_BUS: begin
@@ -743,41 +745,7 @@ always @(posedge CLK) begin
         end
       endcase
       cpu_op <= cpu_op_w;
-
-      casex(cpu_op_w[15:11])
-        5'b00100: begin // SKIP
-          cpu_wait <= op_skip_taken ? 8'h01 : 8'h00;
-          CPU_STATE <= (op_skip_taken && !speed) ? ST_CPU_4 : ST_CPU_0;
-        end
-        5'b00111: begin // RT
-          cpu_wait <= 8'h02;
-          CPU_STATE <= speed ? ST_CPU_0 : ST_CPU_4;
-        end
-        5'b00x01, 5'b00x10: begin // JP
-          if(cpu_op_w[13]) begin // CALL
-            cpu_wait <= op_jp_taken ? 8'h02 : 8'h00;
-          end else begin
-            cpu_wait <= op_jp_taken ? 8'h02 : 8'h00;
-          end
-          CPU_STATE <= (op_jp_taken && !speed) ? ST_CPU_4 : ST_CPU_0;
-        end
-/*        5'b01110, 5'b01101, 5'b11101: begin // RDROM, RDRAM, WRRAM
-          cpu_wait <= 8'h03;
-          CPU_STATE <= speed ? ST_CPU_0 : ST_CPU_4;
-        end
-/*        5'b10011: begin // MUL
-          cpu_wait <= 8'h03;
-          CPU_STATE <= ST_CPU_4;
-        end*/
-/*        5'b01000: begin // BUSRD
-          cpu_wait <= 8'h03;
-          CPU_STATE <= ST_CPU_4;
-        end*/
-        default: begin
-          cpu_wait <= 8'h00;
-          CPU_STATE <= ST_CPU_0;
-        end
-      endcase
+      CPU_STATE <= ST_CPU_0;
 
       casex(cpu_op_w[15:11])
         5'b00000: op <= OP_NOP;
@@ -826,7 +794,7 @@ always @(posedge CLK) begin
       if(cpu_wait_subcyc == 2'b11) begin
         cpu_wait_subcyc <= 2'b00;
         cpu_wait <= cpu_wait - 1;
-        if(cpu_wait == 8'h01) CPU_STATE <= ST_CPU_0;
+        if(cpu_wait == 8'h01) CPU_STATE <= ST_CPU_2;
         else CPU_STATE <= ST_CPU_4;
       end else begin
         cpu_wait_subcyc <= cpu_wait_subcyc + 1;
@@ -863,6 +831,7 @@ always @(posedge CLK) begin
       ST_BUSRD_END: begin
         if(~cpu_busaddr[22]) cpu_busdata <= BUS_DI;
         else cpu_busdata <= 8'h00;
+        BUSRD_STATE <= ST_BUSRD_IDLE;
       end
     endcase
   end

--- a/verilog/sd2snes_cx4/cx4.v
+++ b/verilog/sd2snes_cx4/cx4.v
@@ -623,6 +623,9 @@ always @(posedge CLK) begin
               cpu_wait <= 8'h02;
               CPU_STATE <= speed ? ST_CPU_2 : ST_CPU_4;
             end else cpu_pc <= cpu_pc + 1;
+          end else begin
+            CPU_STATE <= ST_CPU_1;
+            condtrue <= condtrue;
           end
         end
         OP_SKIP: begin
@@ -639,7 +642,10 @@ always @(posedge CLK) begin
           cpu_wait <= 8'h02;
           CPU_STATE <= speed ? ST_CPU_2 : ST_CPU_4;
         end
-        OP_WAI: if(BUS_RDY) cpu_pc <= cpu_pc + 1;
+        OP_WAI: begin
+          if(BUS_RDY) cpu_pc <= cpu_pc + 1;
+          else CPU_STATE <= ST_CPU_1;
+        end
         OP_BUS: begin
           cpu_bus_rq <= 1'b0;
           cpu_pc <= cpu_pc + 1;

--- a/verilog/sd2snes_cx4/main.v
+++ b/verilog/sd2snes_cx4/main.v
@@ -680,7 +680,7 @@ always @(posedge CLK2) begin
       if(cx4_active) begin
         if (CX4_RD_PENDr) begin
           STATE <= ST_CX4_RD_ADDR;
-          ST_MEM_DELAYr <= 16;
+          ST_MEM_DELAYr <= 9;
         end
       end else if(free_slot | SNES_DEADr) begin
         if(MCU_RD_PENDr) begin

--- a/verilog/sd2snes_cx4/main.v
+++ b/verilog/sd2snes_cx4/main.v
@@ -680,7 +680,7 @@ always @(posedge CLK2) begin
       if(cx4_active) begin
         if (CX4_RD_PENDr) begin
           STATE <= ST_CX4_RD_ADDR;
-          ST_MEM_DELAYr <= 9;
+          ST_MEM_DELAYr <= 10;
         end
       end else if(free_slot | SNES_DEADr) begin
         if(MCU_RD_PENDr) begin


### PR DESCRIPTION
- Remove extra cycle on cache trigger
- Make cache triggers on $1F48 writes unconditional
- Fix cache triggers on jumps occurring if branch condition isn't met
- Implement reverse engineered timings for JP/CALL, SKIP, and RET
- Fix BUSRD never returning to idle when finished
- Stay in ST_CPU_1 when waiting for conditions in OP_JP and OP_WAI
- Adjust hardcoded bus read delay

One other thing I had in mind but didn't implement was using WS1 for the bus read delay. I wasn't sure what the best way of implementing that would be because I don't have a full understanding of how the core reads from the bus and how many cycles that really takes, and how you would take that into account when using WS1, so I opted for adjusting the constant. With the other changes, 16 ran too slow compared to original carts, but 10 has very close results in MMX2/3.

Other than CX4-lag heavy sections and wireframe timing being more accurate to the original carts, one of the more significant improvements with these changes is that the X2 intro demo now syncs, whereas before X would end up dying. Here's a video with some quick comparisons: https://www.youtube.com/watch?v=5g1n6vVjAMc

These changes were only tested on a MK2 since that's the only SD2SNES I own.